### PR TITLE
[Change] Switch `c_min_c_plus` conventions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ authors = ["QuantumKitHub"]
 version = "0.1.0"
 
 [deps]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 
 [compat]
 Aqua = "0.8.9"
+JuliaFormatter = "1.0.62"
 LinearAlgebra = "1"
 SafeTestsets = "0.1"
 StableRNGs = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,11 @@ authors = ["QuantumKitHub"]
 version = "0.1.0"
 
 [deps]
-JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 
 [compat]
 Aqua = "0.8.9"
-JuliaFormatter = "1.0.62"
 LinearAlgebra = "1"
 SafeTestsets = "0.1"
 StableRNGs = "1"

--- a/src/fermionoperators.jl
+++ b/src/fermionoperators.jl
@@ -66,7 +66,7 @@ Return the two-body operator that annihilates a particle at the first site and c
 function c_min_c_plus(T::Type{<:Number}=ComplexF64)
     t = two_site_operator(T)
     I = sectortype(t)
-    t[(I(0), I(1), dual(I(1)), dual(I(0)))] .= 1
+    t[(I(0), I(1), dual(I(1)), dual(I(0)))] .= -1
     return t
 end
 const c⁻c⁺ = c_min_c_plus
@@ -106,7 +106,7 @@ Return the two-body operator that describes a particle that hops between the fir
 This is the sum of `c_plus_c_min` and `c_min_c_plus`.
 """ c_hop
 function c_hop(T::Type{<:Number}=ComplexF64)
-    return c_plus_c_min(T) + c_min_c_plus(T)
+    return c_plus_c_min(T) - c_min_c_plus(T)
 end
 
 end

--- a/src/fermionoperators.jl
+++ b/src/fermionoperators.jl
@@ -5,7 +5,6 @@ using TensorKit
 export fermion_space
 export c_num
 export c_plus_c_min, c_min_c_plus, c_plus_c_plus, c_min_c_min
-export c_hop
 export n
 export c⁺c⁻, c⁻c⁺, c⁺c⁺, c⁻c⁻
 
@@ -98,15 +97,5 @@ function c_min_c_min(T::Type{<:Number}=ComplexF64)
     return t
 end
 const c⁻c⁻ = c_min_c_min
-
-@doc """
-    c_hop([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-
-Return the two-body operator that describes a particle that hops between the first and the second site.
-This is the sum of `c_plus_c_min` and `c_min_c_plus`.
-""" c_hop
-function c_hop(T::Type{<:Number}=ComplexF64)
-    return c_plus_c_min(T) - c_min_c_plus(T)
-end
 
 end

--- a/src/fermionoperators.jl
+++ b/src/fermionoperators.jl
@@ -5,6 +5,7 @@ using TensorKit
 export fermion_space
 export c_num
 export c_plus_c_min, c_min_c_plus, c_plus_c_plus, c_min_c_min
+export c_hop
 export n
 export c⁺c⁻, c⁻c⁺, c⁺c⁺, c⁻c⁻
 
@@ -97,5 +98,15 @@ function c_min_c_min(T::Type{<:Number}=ComplexF64)
     return t
 end
 const c⁻c⁻ = c_min_c_min
+
+@doc """
+    c_hop([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+
+Return the two-body operator that describes a particle that hops between the first and the second site.
+This is the sum of `c_plus_c_min` and `c_min_c_plus`.
+""" c_hop
+function c_hop(T::Type{<:Number}=ComplexF64)
+    return c_plus_c_min(T) + c_min_c_plus(T)
+end
 
 end

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -62,7 +62,7 @@ end
 Return the one-body operator that counts the number of spin-up particles.
 """ u_num
 u_num(P::Type{<:Sector}, S::Type{<:Sector}) = u_num(ComplexF64, P, S)
-function u_num(T::Type{<:Number}, (::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
+function u_num(T::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
     t = single_site_operator(T, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][1, 1] = 1

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -114,7 +114,7 @@ const nꜛ = u_num
 Return the one-body operator that counts the number of spin-down particles.
 """ d_num
 d_num(P::Type{<:Sector}, S::Type{<:Sector}) = d_num(ComplexF64, P, S)
-function d_num(T::Type{<:Number}, (::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
+function d_num(T::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
     t = single_site_operator(T, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][2, 2] = 1

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -17,7 +17,7 @@ export n, nꜛ, nꜜ, nꜛꜜ
 Return the local hilbert space for a Hubbard-type model with the given particle and spin symmetries.
 The possible symmetries are `Trivial`, `U1Irrep`, and `SU2Irrep`, for both particle number and spin.
 """
-function hubbard_space(::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
+function hubbard_space((::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
     return Vect[FermionParity](0 => 2, 1 => 2)
 end
 function hubbard_space(::Type{Trivial}, ::Type{U1Irrep})
@@ -62,7 +62,7 @@ end
 Return the one-body operator that counts the number of spin-up particles.
 """ u_num
 u_num(P::Type{<:Sector}, S::Type{<:Sector}) = u_num(ComplexF64, P, S)
-function u_num(T::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
+function u_num(T::Type{<:Number}, (::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
     t = single_site_operator(T, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][1, 1] = 1
@@ -114,7 +114,7 @@ const nꜛ = u_num
 Return the one-body operator that counts the number of spin-down particles.
 """ d_num
 d_num(P::Type{<:Sector}, S::Type{<:Sector}) = d_num(ComplexF64, P, S)
-function d_num(T::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
+function d_num(T::Type{<:Number}, (::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
     t = single_site_operator(T, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][2, 2] = 1

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -5,7 +5,6 @@ using TensorKit
 export hubbard_space
 export c_plus_c_min, u_plus_u_min, d_plus_d_min
 export c_min_c_plus, u_min_u_plus, d_min_d_plus
-export c_hop
 export c_num, u_num, d_num, ud_num
 
 export c⁺c⁻, u⁺u⁻, d⁺d⁻, c⁻c⁺, u⁻u⁺, d⁻d⁺
@@ -428,17 +427,5 @@ function c_min_c_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{
     return -copy(adjoint(c_plus_c_min(T, particle_symmetry, spin_symmetry)))
 end
 const c⁻c⁺ = c_min_c_plus
-
-@doc """
-    c_hop([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-
-Return the two-body operator that describes a particle that hops between the first and the second site.
-This is the sum of `c_plus_c_min` and `c_min_c_plus`.
-""" c_hop
-c_hop(P::Type{<:Sector}, S::Type{<:Sector}) = c_hop(ComplexF64, P, S)
-function c_hop(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
-    return c_plus_c_min(T, particle_symmetry, spin_symmetry) -
-           c_min_c_plus(T, particle_symmetry, spin_symmetry)
-end
 
 end

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -17,7 +17,7 @@ export n, nꜛ, nꜜ, nꜛꜜ
 Return the local hilbert space for a Hubbard-type model with the given particle and spin symmetries.
 The possible symmetries are `Trivial`, `U1Irrep`, and `SU2Irrep`, for both particle number and spin.
 """
-function hubbard_space((::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
+function hubbard_space(::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
     return Vect[FermionParity](0 => 2, 1 => 2)
 end
 function hubbard_space(::Type{Trivial}, ::Type{U1Irrep})

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -425,7 +425,7 @@ This is the sum of `u_min_u_plus` and `d_min_d_plus`.
 """ c_min_c_plus
 c_min_c_plus(P::Type{<:Sector}, S::Type{<:Sector}) = c_min_c_plus(ComplexF64, P, S)
 function c_min_c_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
-    return copy(adjoint(c_plus_c_min(T, particle_symmetry, spin_symmetry)))
+    return -copy(adjoint(c_plus_c_min(T, particle_symmetry, spin_symmetry)))
 end
 const c⁻c⁺ = c_min_c_plus
 
@@ -437,7 +437,7 @@ This is the sum of `c_plus_c_min` and `c_min_c_plus`.
 """ c_hop
 c_hop(P::Type{<:Sector}, S::Type{<:Sector}) = c_hop(ComplexF64, P, S)
 function c_hop(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
-    return c_plus_c_min(T, particle_symmetry, spin_symmetry) +
+    return c_plus_c_min(T, particle_symmetry, spin_symmetry) -
            c_min_c_plus(T, particle_symmetry, spin_symmetry)
 end
 

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -5,6 +5,7 @@ using TensorKit
 export hubbard_space
 export c_plus_c_min, u_plus_u_min, d_plus_d_min
 export c_min_c_plus, u_min_u_plus, d_min_d_plus
+export c_hop
 export c_num, u_num, d_num, ud_num
 
 export c⁺c⁻, u⁺u⁻, d⁺d⁻, c⁻c⁺, u⁻u⁺, d⁻d⁺
@@ -427,5 +428,17 @@ function c_min_c_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{
     return copy(adjoint(c_plus_c_min(T, particle_symmetry, spin_symmetry)))
 end
 const c⁻c⁺ = c_min_c_plus
+
+@doc """
+    c_hop([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+
+Return the two-body operator that describes a particle that hops between the first and the second site.
+This is the sum of `c_plus_c_min` and `c_min_c_plus`.
+""" c_hop
+c_hop(P::Type{<:Sector}, S::Type{<:Sector}) = c_hop(ComplexF64, P, S)
+function c_hop(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    return c_plus_c_min(T, particle_symmetry, spin_symmetry) +
+           c_min_c_plus(T, particle_symmetry, spin_symmetry)
+end
 
 end

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -32,7 +32,7 @@ Setting `slave_fermion = true` switches to the slave-fermion basis.
 - basis states for `slave_fermion = true`: (c_σ = h† b_σ; holon h is fermionic, spinon b_σ is bosonic): 
     |0⟩ = h†|vac⟩, |↑⟩ = (b↑)†|vac⟩, |↓⟩ = (b↓)†|vac⟩
 """
-function tj_space((::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial;
+function tj_space(::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial;
                   slave_fermion::Bool=false)
     return slave_fermion ? Vect[FermionParity](0 => 2, 1 => 1) :
            Vect[FermionParity](0 => 1, 1 => 2)

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -610,7 +610,7 @@ function c_min_c_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=
 end
 function c_min_c_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
-    return copy(adjoint(c_plus_c_min(T, particle_symmetry, spin_symmetry; slave_fermion)))
+    return -copy(adjoint(c_plus_c_min(T, particle_symmetry, spin_symmetry; slave_fermion)))
 end
 const c⁻c⁺ = c_min_c_plus
 
@@ -639,7 +639,7 @@ function c_hop(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
 end
 function c_hop(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                slave_fermion::Bool=false)
-    return c_plus_c_min(T, particle_symmetry, spin_symmetry; slave_fermion) +
+    return c_plus_c_min(T, particle_symmetry, spin_symmetry; slave_fermion) -
            c_min_c_plus(T, particle_symmetry, spin_symmetry; slave_fermion)
 end
 

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -8,7 +8,7 @@ export S_x, S_y, S_z, S_plus, S_min
 export u_plus_u_min, d_plus_d_min
 export u_min_u_plus, d_min_d_plus
 export u_min_d_min, d_min_u_min
-export c_plus_c_min, c_min_c_plus, c_singlet, c_hop
+export c_plus_c_min, c_min_c_plus, c_singlet
 export S_plusmin, S_minplus, S_exchange
 
 export nꜛ, nꜜ, nʰ, n
@@ -626,21 +626,6 @@ function c_singlet(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:S
                    slave_fermion::Bool=false)
     return (u_min_d_min(T, particle_symmetry, spin_symmetry; slave_fermion) -
             d_min_u_min(T, particle_symmetry, spin_symmetry; slave_fermion)) / sqrt(2)
-end
-
-@doc """
-    c_hop([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator that describes a particle that hops between the first and the second site.
-This is the sum of `c_plus_c_min` and `c_min_c_plus`.
-""" c_hop
-function c_hop(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
-    return c_hop(ComplexF64, P, S; slave_fermion)
-end
-function c_hop(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
-               slave_fermion::Bool=false)
-    return c_plus_c_min(T, particle_symmetry, spin_symmetry; slave_fermion) -
-           c_min_c_plus(T, particle_symmetry, spin_symmetry; slave_fermion)
 end
 
 @doc """

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -8,7 +8,7 @@ export S_x, S_y, S_z, S_plus, S_min
 export u_plus_u_min, d_plus_d_min
 export u_min_u_plus, d_min_d_plus
 export u_min_d_min, d_min_u_min
-export c_plus_c_min, c_min_c_plus, c_singlet
+export c_plus_c_min, c_min_c_plus, c_singlet, c_hop
 export S_plusmin, S_minplus, S_exchange
 
 export nꜛ, nꜜ, nʰ, n
@@ -32,7 +32,7 @@ Setting `slave_fermion = true` switches to the slave-fermion basis.
 - basis states for `slave_fermion = true`: (c_σ = h† b_σ; holon h is fermionic, spinon b_σ is bosonic): 
     |0⟩ = h†|vac⟩, |↑⟩ = (b↑)†|vac⟩, |↓⟩ = (b↓)†|vac⟩
 """
-function tj_space(::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial;
+function tj_space((::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial;
                   slave_fermion::Bool=false)
     return slave_fermion ? Vect[FermionParity](0 => 2, 1 => 1) :
            Vect[FermionParity](0 => 1, 1 => 2)
@@ -626,6 +626,21 @@ function c_singlet(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:S
                    slave_fermion::Bool=false)
     return (u_min_d_min(T, particle_symmetry, spin_symmetry; slave_fermion) -
             d_min_u_min(T, particle_symmetry, spin_symmetry; slave_fermion)) / sqrt(2)
+end
+
+@doc """
+    c_hop([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator that describes a particle that hops between the first and the second site.
+This is the sum of `c_plus_c_min` and `c_min_c_plus`.
+""" c_hop
+function c_hop(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return c_hop(ComplexF64, P, S; slave_fermion)
+end
+function c_hop(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+               slave_fermion::Bool=false)
+    return c_plus_c_min(T, particle_symmetry, spin_symmetry; slave_fermion) +
+           c_min_c_plus(T, particle_symmetry, spin_symmetry; slave_fermion)
 end
 
 @doc """

--- a/test/fermionoperators.jl
+++ b/test/fermionoperators.jl
@@ -18,14 +18,14 @@ using StableRNGs
     # I don't think I can get all of these to hold simultaneously?
     # @test cc⁺ ≈ -permute(c⁺c, (2, 1), (4, 3))
 
-    @test c⁻c⁺()' ≈ c⁺c⁻()
+    @test c⁻c⁺()' ≈ -c⁺c⁻()
     @test c⁻c⁻()' ≈ c⁺c⁺()
-    @test (c⁺c⁻() + c⁻c⁺())' ≈ c⁻c⁺() + c⁺c⁻()
-    @test (c⁺c⁻() - c⁻c⁺())' ≈ c⁻c⁺() - c⁺c⁻()
+    @test (c⁺c⁻() - c⁻c⁺())' ≈ c⁺c⁻() - c⁻c⁺()
+    @test (c⁺c⁻() + c⁻c⁺())' ≈ -(c⁻c⁺() + c⁺c⁻())
 
     @plansor c_number[-1; -2] := c⁺c⁻()[-1 1; 3 2] * τ[3 2; -2 1]
     @test c_number ≈ c_num()
-    @test c_hop() ≈ c_plus_c_min() + c_min_c_plus()
+    @test c_hop() ≈ c_plus_c_min() - c_min_c_plus()
 end
 
 @testset "Exact Diagonalization" begin
@@ -35,7 +35,7 @@ end
     t, V, mu = rand(rng, 3)
     pspace = fermion_space()
 
-    H = -t * (c⁻c⁺() + c⁺c⁻()) +
+    H = -t * c_hop() +
         V * ((n() - 0.5 * id(pspace)) ⊗ (n() - 0.5 * id(pspace))) -
         0.5 * mu * (n() ⊗ id(pspace) + id(pspace) ⊗ n())
 

--- a/test/fermionoperators.jl
+++ b/test/fermionoperators.jl
@@ -25,7 +25,6 @@ using StableRNGs
 
     @plansor c_number[-1; -2] := c⁺c⁻()[-1 1; 3 2] * τ[3 2; -2 1]
     @test c_number ≈ c_num()
-    @test c_hop() ≈ c_plus_c_min() - c_min_c_plus()
 end
 
 @testset "Exact Diagonalization" begin
@@ -35,7 +34,7 @@ end
     t, V, mu = rand(rng, 3)
     pspace = fermion_space()
 
-    H = -t * c_hop() +
+    H = -t * (c⁺c⁻() - c⁻c⁺()) +
         V * ((n() - 0.5 * id(pspace)) ⊗ (n() - 0.5 * id(pspace))) -
         0.5 * mu * (n() ⊗ id(pspace) + id(pspace) ⊗ n())
 

--- a/test/fermionoperators.jl
+++ b/test/fermionoperators.jl
@@ -25,6 +25,7 @@ using StableRNGs
 
     @plansor c_number[-1; -2] := c⁺c⁻()[-1 1; 3 2] * τ[3 2; -2 1]
     @test c_number ≈ c_num()
+    @test c_hop() ≈ c_plus_c_min() + c_min_c_plus()
 end
 
 @testset "Exact Diagonalization" begin

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -54,6 +54,11 @@ end
                       u_min_u_plus(particle_symmetry, spin_symmetry)
             end
 
+            # test hopping operator
+            @test c_hop(particle_symmetry, spin_symmetry) ≈
+            c_plus_c_min(particle_symmetry, spin_symmetry) +
+            c_min_c_plus(particle_symmetry, spin_symmetry)
+      
             # test number operator
             if spin_symmetry !== SU2Irrep
                 @test c_num(particle_symmetry, spin_symmetry) ≈

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -42,7 +42,7 @@ end
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             # test hermiticity
             @test c_plus_c_min(particle_symmetry, spin_symmetry)' ≈
-                  c_min_c_plus(particle_symmetry, spin_symmetry)
+                  -c_min_c_plus(particle_symmetry, spin_symmetry)
             if spin_symmetry !== SU2Irrep
                 @test d_plus_d_min(particle_symmetry, spin_symmetry)' ≈
                       d_min_d_plus(particle_symmetry, spin_symmetry)
@@ -56,7 +56,7 @@ end
 
             # test hopping operator
             @test c_hop(particle_symmetry, spin_symmetry) ≈
-                  c_plus_c_min(particle_symmetry, spin_symmetry) +
+                  c_plus_c_min(particle_symmetry, spin_symmetry) -
                   c_min_c_plus(particle_symmetry, spin_symmetry)
 
             # test number operator
@@ -83,8 +83,7 @@ end
 end
 
 function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu, L)
-    hopping = t * (c_plus_c_min(particle_symmetry, spin_symmetry) +
-                   c_min_c_plus(particle_symmetry, spin_symmetry))
+    hopping = -t * c_hop(particle_symmetry, spin_symmetry)
     interaction = U * ud_num(particle_symmetry, spin_symmetry)
     chemical_potential = mu * c_num(particle_symmetry, spin_symmetry)
     I = id(hubbard_space(particle_symmetry, spin_symmetry))

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -54,11 +54,6 @@ end
                       u_min_u_plus(particle_symmetry, spin_symmetry)
             end
 
-            # test hopping operator
-            @test c_hop(particle_symmetry, spin_symmetry) ≈
-                  c_plus_c_min(particle_symmetry, spin_symmetry) -
-                  c_min_c_plus(particle_symmetry, spin_symmetry)
-
             # test number operator
             if spin_symmetry !== SU2Irrep
                 @test c_num(particle_symmetry, spin_symmetry) ≈
@@ -83,7 +78,8 @@ end
 end
 
 function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu, L)
-    hopping = -t * c_hop(particle_symmetry, spin_symmetry)
+    hopping = -t * (c_plus_c_min(particle_symmetry, spin_symmetry) -
+                    c_min_c_plus(particle_symmetry, spin_symmetry))
     interaction = U * ud_num(particle_symmetry, spin_symmetry)
     chemical_potential = mu * c_num(particle_symmetry, spin_symmetry)
     I = id(hubbard_space(particle_symmetry, spin_symmetry))

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -56,9 +56,9 @@ end
 
             # test hopping operator
             @test c_hop(particle_symmetry, spin_symmetry) ≈
-            c_plus_c_min(particle_symmetry, spin_symmetry) +
-            c_min_c_plus(particle_symmetry, spin_symmetry)
-      
+                  c_plus_c_min(particle_symmetry, spin_symmetry) +
+                  c_min_c_plus(particle_symmetry, spin_symmetry)
+
             # test number operator
             if spin_symmetry !== SU2Irrep
                 @test c_num(particle_symmetry, spin_symmetry) ≈

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -67,6 +67,11 @@ end
                                                             slave_fermion)
                 end
 
+                # test hopping operator
+                @test c_hop(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                      c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) +
+                      c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)
+
                 # test number operator
                 if spin_symmetry !== SU2Irrep
                     @test c_num(particle_symmetry, spin_symmetry; slave_fermion) ≈

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -67,11 +67,6 @@ end
                                                             slave_fermion)
                 end
 
-                # test hopping operator
-                @test c_hop(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                      c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) -
-                      c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)
-
                 # test number operator
                 if spin_symmetry !== SU2Irrep
                     @test c_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
@@ -146,25 +141,13 @@ end
     end
 end
 
-function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu, L)
-    hopping = t * c_hop(particle_symmetry, spin_symmetry)
-    chemical_potential = mu * c_num(particle_symmetry, spin_symmetry)
-    I = id(tj_space(particle_symmetry, spin_symmetry))
-    H = sum(1:(L - 1)) do i
-        return reduce(⊗, insert!(collect(Any, fill(I, L - 2)), i, hopping))
-    end +
-        sum(1:L) do i
-        return reduce(⊗, insert!(collect(Any, fill(I, L - 1)), i, chemical_potential))
-    end
-    return H
-end
-
 function tjhamiltonian(particle_symmetry, spin_symmetry; t, J, mu, L, slave_fermion)
     num = c_num(particle_symmetry, spin_symmetry; slave_fermion)
-    hop_heis = (-t) * c_hop(particle_symmetry, spin_symmetry; slave_fermion)
-    J *
-    (S_exchange(particle_symmetry, spin_symmetry; slave_fermion) -
-     (1 / 4) * (num ⊗ num))
+    hop_heis = (-t) * (c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) -
+                       c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)) +
+               J *
+               (S_exchange(particle_symmetry, spin_symmetry; slave_fermion) -
+                (1 / 4) * (num ⊗ num))
     chemical_potential = (-mu) * num
     I = id(tj_space(particle_symmetry, spin_symmetry; slave_fermion))
     H = sum(1:(L - 1)) do i
@@ -220,7 +203,9 @@ end
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 t, J = rand(rng, 2)
                 num = c_num(particle_symmetry, spin_symmetry; slave_fermion)
-                H = (-t) * c_hop(particle_symmetry, spin_symmetry; slave_fermion) +
+                H = (-t) *
+                    (c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) -
+                     c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)) +
                     J *
                     (S_exchange(particle_symmetry, spin_symmetry; slave_fermion) -
                      (1 / 4) * (num ⊗ num))

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -42,7 +42,7 @@ end
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 # test hermiticity
                 @test c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
-                      c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)
+                      -c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)
                 if spin_symmetry !== SU2Irrep
                     @test d_plus_d_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
                           d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
@@ -69,7 +69,7 @@ end
 
                 # test hopping operator
                 @test c_hop(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                      c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) +
+                      c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) -
                       c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)
 
                 # test number operator
@@ -147,8 +147,7 @@ end
 end
 
 function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu, L)
-    hopping = t * (c_plus_c_min(particle_symmetry, spin_symmetry) +
-                   c_min_c_plus(particle_symmetry, spin_symmetry))
+    hopping = t * c_hop(particle_symmetry, spin_symmetry)
     chemical_potential = mu * c_num(particle_symmetry, spin_symmetry)
     I = id(tj_space(particle_symmetry, spin_symmetry))
     H = sum(1:(L - 1)) do i
@@ -162,11 +161,10 @@ end
 
 function tjhamiltonian(particle_symmetry, spin_symmetry; t, J, mu, L, slave_fermion)
     num = c_num(particle_symmetry, spin_symmetry; slave_fermion)
-    hop_heis = (-t) * (c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) +
-                       c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)) +
-               J *
-               (S_exchange(particle_symmetry, spin_symmetry; slave_fermion) -
-                (1 / 4) * (num ⊗ num))
+    hop_heis = (-t) * c_hop(particle_symmetry, spin_symmetry; slave_fermion)
+    J *
+    (S_exchange(particle_symmetry, spin_symmetry; slave_fermion) -
+     (1 / 4) * (num ⊗ num))
     chemical_potential = (-mu) * num
     I = id(tj_space(particle_symmetry, spin_symmetry; slave_fermion))
     H = sum(1:(L - 1)) do i
@@ -222,9 +220,7 @@ end
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 t, J = rand(rng, 2)
                 num = c_num(particle_symmetry, spin_symmetry; slave_fermion)
-                H = (-t) *
-                    (c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) +
-                     c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)) +
+                H = (-t) * c_hop(particle_symmetry, spin_symmetry; slave_fermion) +
                     J *
                     (S_exchange(particle_symmetry, spin_symmetry; slave_fermion) -
                      (1 / 4) * (num ⊗ num))


### PR DESCRIPTION
This implements the hopping operator.

In this PR, we should maybe also think about what we want to do with the operator `c_min_c_plus` in light of the discussion with @lkdvos and @Jutho about [periodic boundary conditions for fermions](https://github.com/QuantumKitHub/MPSKit.jl/pull/274).

