### PR TITLE
Yet Another TensorKitTensors Convention Change

### DIFF
--- a/src/bosonoperators.jl
+++ b/src/bosonoperators.jl
@@ -75,7 +75,7 @@ const b⁺ = b_plus
     n([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic number operator, with a maximum of `cutoff` bosons per site.
-""" number
+""" b_num
 b_num(; kwargs...) = b_num(ComplexF64, Trivial; kwargs...)
 b_num(elt::Type{<:Number}; kwargs...) = b_num(elt, Trivial; kwargs...)
 b_num(symm::Type{<:Sector}; kwargs...) = b_num(ComplexF64, symm; kwargs...)

--- a/src/bosonoperators.jl
+++ b/src/bosonoperators.jl
@@ -24,7 +24,7 @@ boson_space(::Type{U1Irrep}; cutoff::Integer) = U1Space(n => 1 for n in 0:cutoff
 # ---------------------
 @doc """
     b_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    a([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic annihilation operator, with a maximum of `cutoff` bosons per site.
 """ b_min
@@ -48,7 +48,7 @@ const b⁻ = b_min
 
 @doc """
     b_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    a⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic creation operator, with a maximum of `cutoff` bosons per site.
 """ b_plus
@@ -102,7 +102,7 @@ const n = b_num
 # ------------------
 @doc """
     b_plus_b_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    a⁺a⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁺b⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic pair-creation operator, with a maximum of `cutoff` bosons per site.
 """ b_plus_b_plus
@@ -122,7 +122,7 @@ const b⁺b⁺ = b_plus_b_plus
 
 @doc """
     b_plus_b_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    a⁺a([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁺b⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic left-hopping operator, with a maximum of `cutoff` bosons per site.
 """ b_plus_b_min
@@ -151,7 +151,7 @@ const b⁺b⁻ = b_plus_b_min
 
 @doc """
     b_min_b_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    aa⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁻b⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic right-hopping operator, with a maximum of `cutoff` bosons per site.
 """ b_min_b_plus
@@ -180,7 +180,7 @@ const b⁻b⁺ = b_min_b_plus
 
 @doc """
     b_min_b_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    aa([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁻b⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic pair-annihilation operator, with a maximum of `cutoff` bosons per site.
 """ b_min_b_min

--- a/src/bosonoperators.jl
+++ b/src/bosonoperators.jl
@@ -203,7 +203,7 @@ const b⁻b⁻ = b_min_b_min
     b_hop([elt::Type{<:Number}])
 
 Return the two-body operator that describes a particle that hops between the first and the second site.
-""" b_hop
+""" b_hopping
 b_hopping(; kwargs...) = b_hopping(ComplexF64, Trivial; kwargs...)
 function b_hopping(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
     return b_plus_b_min(elt, symmetry; cutoff) + b_min_b_plus(elt, symmetry; cutoff)

--- a/src/bosonoperators.jl
+++ b/src/bosonoperators.jl
@@ -23,8 +23,8 @@ boson_space(::Type{U1Irrep}; cutoff::Integer) = U1Space(n => 1 for n in 0:cutoff
 # Single-site operators
 # ---------------------
 @doc """
-    b_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    b⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_min([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁻([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic annihilation operator, with a maximum of `cutoff` bosons per site.
 """ b_min
@@ -47,8 +47,8 @@ end
 const b⁻ = b_min
 
 @doc """
-    b_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    b⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_plus([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁺([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic creation operator, with a maximum of `cutoff` bosons per site.
 """ b_plus
@@ -71,8 +71,8 @@ end
 const b⁺ = b_plus
 
 @doc """
-    b_num([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    n([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_num([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    n([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic number operator, with a maximum of `cutoff` bosons per site.
 """ b_num
@@ -101,8 +101,8 @@ const n = b_num
 # Two site operators
 # ------------------
 @doc """
-    b_plus_b_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    b⁺b⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_plus_b_plus([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁺b⁺([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic pair-creation operator, with a maximum of `cutoff` bosons per site.
 """ b_plus_b_plus
@@ -121,8 +121,8 @@ end
 const b⁺b⁺ = b_plus_b_plus
 
 @doc """
-    b_plus_b_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    b⁺b⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_plus_b_min([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁺b⁻([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic left-hopping operator, with a maximum of `cutoff` bosons per site.
 """ b_plus_b_min
@@ -150,8 +150,8 @@ end
 const b⁺b⁻ = b_plus_b_min
 
 @doc """
-    b_min_b_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    b⁻b⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_min_b_plus([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁻b⁺([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic right-hopping operator, with a maximum of `cutoff` bosons per site.
 """ b_min_b_plus
@@ -179,8 +179,8 @@ end
 const b⁻b⁺ = b_min_b_plus
 
 @doc """
-    b_min_b_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
-    b⁻b⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_min_b_min([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b⁻b⁻([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic pair-annihilation operator, with a maximum of `cutoff` bosons per site.
 """ b_min_b_min
@@ -199,8 +199,8 @@ end
 const b⁻b⁻ = b_min_b_min
 
 @doc """
-    b_hopping([eltype::Type{<:Number}])
-    b_hop([eltype::Type{<:Number}])
+    b_hopping([elt::Type{<:Number}])
+    b_hop([elt::Type{<:Number}])
 
 Return the two-body operator that describes a particle that hops between the first and the second site.
 """ b_hop

--- a/src/bosonoperators.jl
+++ b/src/bosonoperators.jl
@@ -141,7 +141,7 @@ function b_plus_b_min(elt::Type{<:Number}, ::Type{U1Irrep}; cutoff::Integer)
         c_out, c_in = f1.uncoupled, f2.uncoupled
         if c_in[1].charge + 1 == c_out[1].charge &&
            c_in[2].charge - 1 == c_out[2].charge
-           b⁺b⁻[f1, f2] .= sqrt(c_out[1].charge) * sqrt(c_in[2].charge)
+            b⁺b⁻[f1, f2] .= sqrt(c_out[1].charge) * sqrt(c_in[2].charge)
         end
     end
     return b⁺b⁻
@@ -170,7 +170,7 @@ function b_min_b_plus(elt::Type{<:Number}, ::Type{U1Irrep}; cutoff::Integer)
         c_out, c_in = f1.uncoupled, f2.uncoupled
         if c_in[1].charge - 1 == c_out[1].charge &&
            c_in[2].charge + 1 == c_out[2].charge
-           b⁻b⁺[f1, f2] .= sqrt(c_in[1].charge) * sqrt(c_out[2].charge)
+            b⁻b⁺[f1, f2] .= sqrt(c_in[1].charge) * sqrt(c_out[2].charge)
         end
     end
     return b⁻b⁺
@@ -209,6 +209,5 @@ function b_hopping(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Intege
     return b_plus_b_min(elt, symmetry; cutoff) + b_min_b_plus(elt, symmetry; cutoff)
 end
 const b_hop = b_hopping
-
 
 end

--- a/src/bosonoperators.jl
+++ b/src/bosonoperators.jl
@@ -4,10 +4,12 @@ using TensorKit
 using LinearAlgebra: diagind
 
 export boson_space
-export a_plus, a_min, number
-export a_plusplus, a_plusmin, a_minplus, a_minmin
-export a, a⁺, n
-export a⁺a⁺, aa⁺, a⁺a, aa
+export b_plus, b_min, b_num
+export b_plus_b_plus, b_plus_b_min, b_min_b_plus, b_min_b_min
+export b_hopping
+export b⁻, b⁺, n
+export b⁺b⁺, b⁻b⁺, b⁺b⁻, b⁻b⁻
+export b_hop
 
 """
     boson_space([symmetry::Type{<:Sector}]; cutoff::Integer)
@@ -21,63 +23,63 @@ boson_space(::Type{U1Irrep}; cutoff::Integer) = U1Space(n => 1 for n in 0:cutoff
 # Single-site operators
 # ---------------------
 @doc """
-    a_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     a([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic annihilation operator, with a maximum of `cutoff` bosons per site.
-""" a_min
-a_min(; kwargs...) = a_min(ComplexF64, Trivial; kwargs...)
-a_min(elt::Type{<:Number}; kwargs...) = a_min(elt, Trivial; kwargs...)
-a_min(symm::Type{<:Sector}; kwargs...) = a_min(ComplexF64, symm; kwargs...)
-function a_min(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
+""" b_min
+b_min(; kwargs...) = b_min(ComplexF64, Trivial; kwargs...)
+b_min(elt::Type{<:Number}; kwargs...) = b_min(elt, Trivial; kwargs...)
+b_min(symm::Type{<:Sector}; kwargs...) = b_min(ComplexF64, symm; kwargs...)
+function b_min(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
     if symmetry === Trivial
         pspace = boson_space(Trivial; cutoff)
-        a = zeros(elt, pspace ← pspace)
+        b⁻ = zeros(elt, pspace ← pspace)
         for i in 1:cutoff
-            a[i, i + 1] = sqrt(i)
+            b⁻[i, i + 1] = sqrt(i)
         end
-        return a
+        return b⁻
     else
         throw(ArgumentError("invalid symmetry `$symmetry`"))
     end
 end
 
-const a = a_min
+const b⁻ = b_min
 
 @doc """
-    a_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     a⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic creation operator, with a maximum of `cutoff` bosons per site.
-""" a_plus
-a_plus(; kwargs...) = a_plus(ComplexF64, Trivial; kwargs...)
-a_plus(elt::Type{<:Number}; kwargs...) = a_plus(elt, Trivial; kwargs...)
-a_plus(symm::Type{<:Sector}; kwargs...) = a_plus(ComplexF64, symm; kwargs...)
-function a_plus(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
+""" b_plus
+b_plus(; kwargs...) = b_plus(ComplexF64, Trivial; kwargs...)
+b_plus(elt::Type{<:Number}; kwargs...) = b_plus(elt, Trivial; kwargs...)
+b_plus(symm::Type{<:Sector}; kwargs...) = b_plus(ComplexF64, symm; kwargs...)
+function b_plus(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
     if symmetry === Trivial
         pspace = boson_space(Trivial; cutoff)
-        a⁺ = zeros(elt, pspace ← pspace)
+        b⁺ = zeros(elt, pspace ← pspace)
         for i in 1:cutoff
-            a⁺[i + 1, i] = sqrt(i)
+            b⁺[i + 1, i] = sqrt(i)
         end
-        return a⁺
+        return b⁺
     else
         throw(ArgumentError("invalid symmetry `$symmetry`"))
     end
 end
 
-const a⁺ = a_plus
+const b⁺ = b_plus
 
 @doc """
-    number([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_num([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     n([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic number operator, with a maximum of `cutoff` bosons per site.
 """ number
-number(; kwargs...) = number(ComplexF64, Trivial; kwargs...)
-number(elt::Type{<:Number}; kwargs...) = number(elt, Trivial; kwargs...)
-number(symm::Type{<:Sector}; kwargs...) = number(ComplexF64, symm; kwargs...)
-function number(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
+b_num(; kwargs...) = b_num(ComplexF64, Trivial; kwargs...)
+b_num(elt::Type{<:Number}; kwargs...) = b_num(elt, Trivial; kwargs...)
+b_num(symm::Type{<:Sector}; kwargs...) = b_num(ComplexF64, symm; kwargs...)
+function b_num(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
     pspace = boson_space(symmetry; cutoff)
     n = zeros(elt, pspace ← pspace)
     if symmetry === Trivial
@@ -94,106 +96,119 @@ function number(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
     return n
 end
 
-const n = number
+const n = b_num
 
 # Two site operators
 # ------------------
 @doc """
-    a_plusplus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_plus_b_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     a⁺a⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic pair-creation operator, with a maximum of `cutoff` bosons per site.
-""" a_plusplus
-a_plusplus(; kwargs...) = a_plusplus(ComplexF64, Trivial; kwargs...)
-a_plusplus(elt::Type{<:Number}; kwargs...) = a_plusplus(elt, Trivial; kwargs...)
-a_plusplus(symm::Type{<:Sector}; kwargs...) = a_plusplus(ComplexF64, symm; kwargs...)
-function a_plusplus(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
+""" b_plus_b_plus
+b_plus_b_plus(; kwargs...) = b_plus_b_plus(ComplexF64, Trivial; kwargs...)
+b_plus_b_plus(elt::Type{<:Number}; kwargs...) = b_plus_b_plus(elt, Trivial; kwargs...)
+b_plus_b_plus(symm::Type{<:Sector}; kwargs...) = b_plus_b_plus(ComplexF64, symm; kwargs...)
+function b_plus_b_plus(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
     if symmetry === Trivial
-        a⁺ = a_plus(elt, Trivial; cutoff)
-        return a⁺ ⊗ a⁺
+        b⁺ = b_plus(elt, Trivial; cutoff)
+        return b⁺ ⊗ b⁺
     else
         throw(ArgumentError("invalid symmetry `$symmetry`"))
     end
 end
 
-const a⁺a⁺ = a_plusplus
+const b⁺b⁺ = b_plus_b_plus
 
 @doc """
-    a_plusmin([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_plus_b_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     a⁺a([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic left-hopping operator, with a maximum of `cutoff` bosons per site.
-""" a_plusmin
-a_plusmin(; kwargs...) = a_plusmin(ComplexF64, Trivial; kwargs...)
-a_plusmin(elt::Type{<:Number}; kwargs...) = a_plusmin(elt, Trivial; kwargs...)
-a_plusmin(symm::Type{<:Sector}; kwargs...) = a_plusmin(ComplexF64, symm; kwargs...)
-function a_plusmin(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
-    a⁺ = a_plus(elt, Trivial; cutoff)
-    a = a_min(elt, Trivial; cutoff)
-    return a⁺ ⊗ a
+""" b_plus_b_min
+b_plus_b_min(; kwargs...) = b_plus_b_min(ComplexF64, Trivial; kwargs...)
+b_plus_b_min(elt::Type{<:Number}; kwargs...) = b_plus_b_min(elt, Trivial; kwargs...)
+b_plus_b_min(symm::Type{<:Sector}; kwargs...) = b_plus_b_min(ComplexF64, symm; kwargs...)
+function b_plus_b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+    b⁺ = b_plus(elt, Trivial; cutoff)
+    b⁻ = b_min(elt, Trivial; cutoff)
+    return b⁺ ⊗ b⁻
 end
-function a_plusmin(elt::Type{<:Number}, ::Type{U1Irrep}; cutoff::Integer)
+function b_plus_b_min(elt::Type{<:Number}, ::Type{U1Irrep}; cutoff::Integer)
     pspace = boson_space(U1Irrep; cutoff)
-    a⁺a = zeros(elt, pspace ⊗ pspace ← pspace ⊗ pspace)
-    for (f1, f2) in fusiontrees(a⁺a)
+    b⁺b⁻ = zeros(elt, pspace ⊗ pspace ← pspace ⊗ pspace)
+    for (f1, f2) in fusiontrees(b⁺b⁻)
         c_out, c_in = f1.uncoupled, f2.uncoupled
         if c_in[1].charge + 1 == c_out[1].charge &&
            c_in[2].charge - 1 == c_out[2].charge
-            a⁺a[f1, f2] .= sqrt(c_out[1].charge) * sqrt(c_in[2].charge)
+           b⁺b⁻[f1, f2] .= sqrt(c_out[1].charge) * sqrt(c_in[2].charge)
         end
     end
-    return a⁺a
+    return b⁺b⁻
 end
 
-const a⁺a = a_plusmin
+const b⁺b⁻ = b_plus_b_min
 
 @doc """
-    a_minplus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_min_b_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     aa⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic right-hopping operator, with a maximum of `cutoff` bosons per site.
-""" a_minplus
-a_minplus(; kwargs...) = a_minplus(ComplexF64, Trivial; kwargs...)
-a_minplus(elt::Type{<:Number}; kwargs...) = a_minplus(elt, Trivial; kwargs...)
-a_minplus(symm::Type{<:Sector}; kwargs...) = a_minplus(ComplexF64, symm; kwargs...)
-function a_minplus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
-    a⁺ = a_plus(elt, Trivial; cutoff)
-    a = a_min(elt, Trivial; cutoff)
-    return a ⊗ a⁺
+""" b_min_b_plus
+b_min_b_plus(; kwargs...) = b_min_b_plus(ComplexF64, Trivial; kwargs...)
+b_min_b_plus(elt::Type{<:Number}; kwargs...) = b_min_b_plus(elt, Trivial; kwargs...)
+b_min_b_plus(symm::Type{<:Sector}; kwargs...) = b_min_b_plus(ComplexF64, symm; kwargs...)
+function b_min_b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+    b⁺ = b_plus(elt, Trivial; cutoff)
+    b⁻ = b_min(elt, Trivial; cutoff)
+    return b⁻ ⊗ b⁺
 end
-function a_minplus(elt::Type{<:Number}, ::Type{U1Irrep}; cutoff::Integer)
+function b_min_b_plus(elt::Type{<:Number}, ::Type{U1Irrep}; cutoff::Integer)
     pspace = boson_space(U1Irrep; cutoff)
-    aa⁺ = zeros(elt, pspace ⊗ pspace ← pspace ⊗ pspace)
-    for (f1, f2) in fusiontrees(aa⁺)
+    b⁻b⁺ = zeros(elt, pspace ⊗ pspace ← pspace ⊗ pspace)
+    for (f1, f2) in fusiontrees(b⁻b⁺)
         c_out, c_in = f1.uncoupled, f2.uncoupled
         if c_in[1].charge - 1 == c_out[1].charge &&
            c_in[2].charge + 1 == c_out[2].charge
-            aa⁺[f1, f2] .= sqrt(c_in[1].charge) * sqrt(c_out[2].charge)
+           b⁻b⁺[f1, f2] .= sqrt(c_in[1].charge) * sqrt(c_out[2].charge)
         end
     end
-    return aa⁺
+    return b⁻b⁺
 end
 
-const aa⁺ = a_minplus
+const b⁻b⁺ = b_min_b_plus
 
 @doc """
-    a_minmin([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
+    b_min_b_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     aa([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic pair-annihilation operator, with a maximum of `cutoff` bosons per site.
-""" a_minmin
-a_minmin(; kwargs...) = a_minmin(ComplexF64, Trivial; kwargs...)
-a_minmin(elt::Type{<:Number}; kwargs...) = a_minmin(elt, Trivial; kwargs...)
-a_minmin(symm::Type{<:Sector}; kwargs...) = a_minmin(ComplexF64, symm; kwargs...)
-function a_minmin(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
+""" b_min_b_min
+b_min_b_min(; kwargs...) = b_min_b_min(ComplexF64, Trivial; kwargs...)
+b_min_b_min(elt::Type{<:Number}; kwargs...) = b_min_b_min(elt, Trivial; kwargs...)
+b_min_b_min(symm::Type{<:Sector}; kwargs...) = b_min_b_min(ComplexF64, symm; kwargs...)
+function b_min_b_min(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
     if symmetry === Trivial
-        a = a_min(elt, Trivial; cutoff)
-        return a ⊗ a
+        b⁻ = b_min(elt, Trivial; cutoff)
+        return b⁻ ⊗ b⁻
     else
         throw(ArgumentError("invalid symmetry `$symmetry`"))
     end
 end
 
-const aa = a_minmin
+const b⁻b⁻ = b_min_b_min
+
+@doc """
+    b_hopping([eltype::Type{<:Number}])
+    b_hop([eltype::Type{<:Number}])
+
+Return the two-body operator that describes a particle that hops between the first and the second site.
+""" b_hop
+b_hopping(; kwargs...) = b_hopping(ComplexF64, Trivial; kwargs...)
+function b_hopping(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
+    return b_plus_b_min(elt, symmetry; cutoff) + b_min_b_plus(elt, symmetry; cutoff)
+end
+const b_hop = b_hopping
+
 
 end

--- a/src/fermionoperators.jl
+++ b/src/fermionoperators.jl
@@ -3,10 +3,12 @@ module FermionOperators
 using TensorKit
 
 export fermion_space
-export c_num
-export c_plus_c_min, c_min_c_plus, c_plus_c_plus, c_min_c_min
+export f_num
+export f_plus_f_min, f_min_f_plus, f_plus_f_plus, f_min_f_min
+export f_hopping
 export n
-export c⁺c⁻, c⁻c⁺, c⁺c⁺, c⁻c⁻
+export f⁺f⁻, f⁻f⁺, f⁺f⁺, f⁻f⁻
+export f_hop
 
 """
     fermion_space()
@@ -23,17 +25,17 @@ function single_site_operator(T)
 end
 
 @doc """
-    c_num([elt::Type{<:Number}=ComplexF64])
+    f_num([elt::Type{<:Number}=ComplexF64])
     n([elt::Type{<:Number}=ComplexF64])
 
 Return the one-body operator that counts the nunber of particles.
-""" c_num
-function c_num(T::Type{<:Number}=ComplexF64)
+""" f_num
+function f_num(T::Type{<:Number}=ComplexF64)
     t = single_site_operator(T)
     block(t, fℤ₂(1)) .= one(T)
     return t
 end
-const n = c_num
+const n = f_num
 
 # Two site operators
 # ------------------
@@ -43,59 +45,70 @@ function two_site_operator(T::Type{<:Number}=ComplexF64)
 end
 
 @doc """
-    c_plus_c_min([elt::Type{<:Number}=ComplexF64])
-    c⁺c⁻([elt::Type{<:Number}=ComplexF64])
+    f_plus_f_min([elt::Type{<:Number}=ComplexF64])
+    f⁺f⁻([elt::Type{<:Number}=ComplexF64])
 
 Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
-""" c_plus_c_min
-function c_plus_c_min(T::Type{<:Number}=ComplexF64)
+""" f_plus_f_min
+function f_plus_f_min(T::Type{<:Number}=ComplexF64)
     t = two_site_operator(T)
     I = sectortype(t)
     t[(I(1), I(0), dual(I(0)), dual(I(1)))] .= 1
     return t
 end
-const c⁺c⁻ = c_plus_c_min
+const f⁺f⁻ = f_plus_f_min
 
 @doc """
-    c_min_c_plus([elt::Type{<:Number}=ComplexF64])
-    c⁻c⁺([elt::Type{<:Number}=ComplexF64])
+    f_min_f_plus([elt::Type{<:Number}=ComplexF64])
+    f⁻f⁺([elt::Type{<:Number}=ComplexF64])
 
 Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
-""" c_min_c_plus
-function c_min_c_plus(T::Type{<:Number}=ComplexF64)
+""" f_min_f_plus
+function f_min_f_plus(T::Type{<:Number}=ComplexF64)
     t = two_site_operator(T)
     I = sectortype(t)
     t[(I(0), I(1), dual(I(1)), dual(I(0)))] .= -1
     return t
 end
-const c⁻c⁺ = c_min_c_plus
+const f⁻f⁺ = f_min_f_plus
 
 @doc """
-    c_plus_c_plus([elt::Type{<:Number}=ComplexF64])
-    c⁺c⁺([elt::Type{<:Number}=ComplexF64])
+    f_plus_f_plus([elt::Type{<:Number}=ComplexF64])
+    f⁺f⁺([elt::Type{<:Number}=ComplexF64])
 
 Return the two-body operator that creates a particle at the first and at the second site.
-""" c_plus_c_plus
-function c_plus_c_plus(T::Type{<:Number}=ComplexF64)
+""" f_plus_f_plus
+function f_plus_f_plus(T::Type{<:Number}=ComplexF64)
     t = two_site_operator(T)
     I = sectortype(t)
     t[(I(1), I(1), dual(I(0)), dual(I(0)))] .= 1
     return t
 end
-const c⁺c⁺ = c_plus_c_plus
+const f⁺f⁺ = f_plus_f_plus
 
 @doc """
-    c_min_c_min([elt::Type{<:Number}=ComplexF64])
-    c⁻c⁻([elt::Type{<:Number}=ComplexF64])
+    f_min_f_min([elt::Type{<:Number}=ComplexF64])
+    f⁻f⁻([elt::Type{<:Number}=ComplexF64])
 
 Return the two-body operator that annihilates a particle at the first and at the second site.
-""" c_min_c_min
-function c_min_c_min(T::Type{<:Number}=ComplexF64)
+""" f_min_f_min
+function f_min_f_min(T::Type{<:Number}=ComplexF64)
     t = two_site_operator(T)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))] .= 1
     return t
 end
-const c⁻c⁻ = c_min_c_min
+const f⁻f⁻ = f_min_f_min
+
+@doc """
+    f_hopping([elt::Type{<:Number}=ComplexF64])
+    f_hop([elt::Type{<:Number}=ComplexF64])
+
+Return the two-body operator that describes a particle that hops between the first and the second site.
+""" f_hopping
+function f_hopping(elt::Type{<:Number}=ComplexF64)
+    return f_plus_f_min(elt) - f_min_f_plus(elt)
+end
+const f_hop = f_hopping
 
 end

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -3,12 +3,14 @@ module HubbardOperators
 using TensorKit
 
 export hubbard_space
-export c_plus_c_min, u_plus_u_min, d_plus_d_min
-export c_min_c_plus, u_min_u_plus, d_min_d_plus
-export c_num, u_num, d_num, ud_num
+export e_plus_e_min, u_plus_u_min, d_plus_d_min
+export e_min_e_plus, u_min_u_plus, d_min_d_plus
+export e_num, u_num, d_num, ud_num
+export e_hopping
 
-export c⁺c⁻, u⁺u⁻, d⁺d⁻, c⁻c⁺, u⁻u⁺, d⁻d⁺
+export e⁺e⁻, u⁺u⁻, d⁺d⁻, e⁻e⁺, u⁻u⁺, d⁻d⁺
 export n, nꜛ, nꜜ, nꜛꜜ
+export e_hop
 
 """
     hubbard_space(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
@@ -61,47 +63,47 @@ end
 Return the one-body operator that counts the number of spin-up particles.
 """ u_num
 u_num(P::Type{<:Sector}, S::Type{<:Sector}) = u_num(ComplexF64, P, S)
-function u_num(T::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
-    t = single_site_operator(T, Trivial, Trivial)
+function u_num(elt::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
+    t = single_site_operator(elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][1, 1] = 1
     t[(I(0), I(0))][2, 2] = 1
     return t
 end
-function u_num(T, ::Type{Trivial}, ::Type{U1Irrep})
-    t = single_site_operator(T, Trivial, U1Irrep)
+function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
+    t = single_site_operator(elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1 // 2), dual(I(1, 1 // 2)))][1, 1] = 1
     t[(I(0, 0), dual(I(0, 0)))][2, 2] = 1
     return t
 end
-function u_num(T, ::Type{Trivial}, ::Type{SU2Irrep})
+function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_num(T, ::Type{U1Irrep}, ::Type{Trivial})
-    t = single_site_operator(T, U1Irrep, Trivial)
+function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
+    t = single_site_operator(elt, U1Irrep, Trivial)
     I = sectortype(t)
     block(t, I(1, 1))[1, 1] = 1
     block(t, I(0, 2))[1, 1] = 1
     return t
 end
-function u_num(T, ::Type{U1Irrep}, ::Type{U1Irrep})
-    t = single_site_operator(T, U1Irrep, U1Irrep)
+function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
+    t = single_site_operator(elt, U1Irrep, U1Irrep)
     I = sectortype(t)
     block(t, I(1, 1, 1 // 2)) .= 1
     block(t, I(0, 2, 0)) .= 1
     return t
 end
-function u_num(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
+function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_num(T, ::Type{SU2Irrep}, ::Type{Trivial})
+function u_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{Trivial})
     return error("Not implemented")
 end
-function u_num(T, ::Type{SU2Irrep}, ::Type{U1Irrep})
+function u_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{U1Irrep})
     return error("Not implemented")
 end
-function u_num(T, ::Type{SU2Irrep}, ::Type{SU2Irrep})
+function u_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const nꜛ = u_num
@@ -113,98 +115,98 @@ const nꜛ = u_num
 Return the one-body operator that counts the number of spin-down particles.
 """ d_num
 d_num(P::Type{<:Sector}, S::Type{<:Sector}) = d_num(ComplexF64, P, S)
-function d_num(T::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
-    t = single_site_operator(T, Trivial, Trivial)
+function d_num(elt::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
+    t = single_site_operator(elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][2, 2] = 1
     t[(I(0), I(0))][2, 2] = 1
     return t
 end
-function d_num(T, ::Type{Trivial}, ::Type{U1Irrep})
-    t = single_site_operator(T, Trivial, U1Irrep)
+function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
+    t = single_site_operator(elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(1, -1 // 2), dual(I(1, -1 // 2)))][1, 1] = 1
     t[(I(0, 0), I(0, 0))][2, 2] = 1
     return t
 end
-function d_num(T, ::Type{Trivial}, ::Type{SU2Irrep})
+function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_num(T, ::Type{U1Irrep}, ::Type{Trivial})
-    t = single_site_operator(T, U1Irrep, Trivial)
+function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
+    t = single_site_operator(elt, U1Irrep, Trivial)
     I = sectortype(t)
     block(t, I(1, 1))[2, 2] = 1 # expected to be [1,2]
     block(t, I(0, 2))[1, 1] = 1
     return t
 end
-function d_num(T, ::Type{U1Irrep}, ::Type{U1Irrep})
-    t = single_site_operator(T, U1Irrep, U1Irrep)
+function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
+    t = single_site_operator(elt, U1Irrep, U1Irrep)
     I = sectortype(t)
     block(t, I(1, 1, -1 // 2)) .= 1
     block(t, I(0, 2, 0)) .= 1
     return t
 end
-function d_num(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
+function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_num(T, ::Type{SU2Irrep}, ::Type{Trivial})
+function d_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{Trivial})
     return error("Not implemented")
 end
-function d_num(T, ::Type{SU2Irrep}, ::Type{U1Irrep})
+function d_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{U1Irrep})
     return error("Not implemented")
 end
-function d_num(T, ::Type{SU2Irrep}, ::Type{SU2Irrep})
+function d_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const nꜜ = d_num
 
 @doc """
-    c_num([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    n([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    n([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of particles.
-""" c_num
-c_num(P::Type{<:Sector}, S::Type{<:Sector}) = c_num(ComplexF64, P, S)
-function c_num(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
-    return u_num(T, particle_symmetry, spin_symmetry) +
-           d_num(T, particle_symmetry, spin_symmetry)
+""" e_num
+e_num(P::Type{<:Sector}, S::Type{<:Sector}) = e_num(ComplexF64, P, S)
+function e_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    return u_num(elt, particle_symmetry, spin_symmetry) +
+           d_num(elt, particle_symmetry, spin_symmetry)
 end
-function c_num(T, ::Type{Trivial}, ::Type{SU2Irrep})
-    t = single_site_operator(T, Trivial, SU2Irrep)
+function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
+    t = single_site_operator(elt, Trivial, SU2Irrep)
     I = sectortype(t)
     block(t, I(1, 1 // 2))[1, 1] = 1
     block(t, I(0, 0))[2, 2] = 2
     return t
 end
-function c_num(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    t = single_site_operator(T, U1Irrep, SU2Irrep)
+function e_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    t = single_site_operator(elt, U1Irrep, SU2Irrep)
     I = sectortype(t)
     block(t, I(1, 1, 1 // 2)) .= 1
     block(t, I(0, 2, 0)) .= 2
     return t
 end
-const n = c_num
+const n = e_num
 
 @doc """
-    ud_num([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    nꜛꜜ([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    ud_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    nꜛꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of doubly occupied sites.
 """ ud_num
 ud_num(P::Type{<:Sector}, S::Type{<:Sector}) = ud_num(ComplexF64, P, S)
-function ud_num(T, particle_symmetry::Type{<:Sector},
+function ud_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
                 spin_symmetry::Type{<:Sector})
-    return u_num(T, particle_symmetry, spin_symmetry) *
-           d_num(T, particle_symmetry, spin_symmetry)
+    return u_num(elt, particle_symmetry, spin_symmetry) *
+           d_num(elt, particle_symmetry, spin_symmetry)
 end
-function ud_num(T, ::Type{Trivial}, ::Type{SU2Irrep})
-    t = single_site_operator(T, Trivial, SU2Irrep)
+function ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
+    t = single_site_operator(elt, Trivial, SU2Irrep)
     I = sectortype(t)
     block(t, I(0, 0))[2, 2] = 1
     return t
 end
-function ud_num(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    t = single_site_operator(T, U1Irrep, SU2Irrep)
+function ud_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    t = single_site_operator(elt, U1Irrep, SU2Irrep)
     I = sectortype(t)
     block(t, I(0, 2, 0)) .= 1
     return t
@@ -213,21 +215,21 @@ const nꜛꜜ = ud_num
 
 # Two site operators
 # ------------------
-function two_site_operator(T, particle_symmetry::Type{<:Sector},
+function two_site_operator(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
                            spin_symmetry::Type{<:Sector})
     V = hubbard_space(particle_symmetry, spin_symmetry)
-    return zeros(T, V ⊗ V ← V ⊗ V)
+    return zeros(elt, V ⊗ V ← V ⊗ V)
 end
 
 @doc """
-    u_plus_u_min([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    u⁺d⁻([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u_plus_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u⁺d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``c†_{1,↑}, c_{2,↑}`` that creates a spin-up particle at the first site and annihilates a spin-up particle at the second.
+Return the two-body operator ``e†_{1,↑}, e_{2,↑}`` that creates a spin-up particle at the first site and annihilates a spin-up particle at the second.
 """ u_plus_u_min
 u_plus_u_min(P::Type{<:Sector}, S::Type{<:Sector}) = u_plus_u_min(ComplexF64, P, S)
-function u_plus_u_min(T, ::Type{Trivial}, ::Type{Trivial})
-    t = two_site_operator(T, Trivial, Trivial)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    t = two_site_operator(elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(0), dual(I(0)), dual(I(1)))][1, 1, 1, 1] = 1
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][1, 2, 1, 2] = 1
@@ -235,8 +237,8 @@ function u_plus_u_min(T, ::Type{Trivial}, ::Type{Trivial})
     t[(I(0), I(1), dual(I(1)), dual(I(0)))][2, 2, 2, 2] = -1
     return t
 end
-function u_plus_u_min(T, ::Type{Trivial}, ::Type{U1Irrep})
-    t = two_site_operator(T, Trivial, U1Irrep)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
+    t = two_site_operator(elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1 // 2), I(0, 0), dual(I(0, 0)), dual(I(1, 1 // 2)))][1, 1, 1, 1] = 1
     t[(I(1, 1 // 2), I(1, -1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 1, 2] = 1
@@ -244,11 +246,11 @@ function u_plus_u_min(T, ::Type{Trivial}, ::Type{U1Irrep})
     t[(I(0, 0), I(1, -1 // 2), dual(I(1, -1 // 2)), dual(I(0, 0)))][2, 1, 1, 2] = -1
     return t
 end
-function u_plus_u_min(T, ::Type{Trivial}, ::Type{SU2Irrep})
+function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_plus_u_min(T, ::Type{U1Irrep}, ::Type{Trivial})
-    t = two_site_operator(T, U1Irrep, Trivial)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
+    t = two_site_operator(elt, U1Irrep, Trivial)
     I = sectortype(t)
     t[(I(1, 1), I(0, 0), dual(I(0, 0)), dual(I(1, 1)))][1, 1, 1, 1] = 1
     t[(I(1, 1), I(1, 1), dual(I(0, 0)), dual(I(0, 2)))][1, 2, 1, 1] = 1
@@ -256,8 +258,8 @@ function u_plus_u_min(T, ::Type{U1Irrep}, ::Type{Trivial})
     t[(I(0, 2), I(1, 1), dual(I(1, 1)), dual(I(0, 2)))][1, 2, 2, 1] = -1
     return t
 end
-function u_plus_u_min(T, ::Type{U1Irrep}, ::Type{U1Irrep})
-    t = two_site_operator(T, U1Irrep, U1Irrep)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
+    t = two_site_operator(elt, U1Irrep, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1, 1 // 2), I(0, 0, 0), dual(I(0, 0, 0)), dual(I(1, 1, 1 // 2)))] .= 1
     t[(I(1, 1, 1 // 2), I(1, 1, -1 // 2), dual(I(0, 0, 0)), dual(I(0, 2, 0)))] .= 1
@@ -265,29 +267,29 @@ function u_plus_u_min(T, ::Type{U1Irrep}, ::Type{U1Irrep})
     t[(I(0, 2, 0), I(1, 1, -1 // 2), dual(I(1, 1, -1 // 2)), dual(I(0, 2, 0)))] .= -1
     return t
 end
-function u_plus_u_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
+function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_plus_u_min(T, ::Type{SU2Irrep}, ::Type{Trivial})
+function u_plus_u_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{Trivial})
     return error("Not implemented")
 end
-function u_plus_u_min(T, ::Type{SU2Irrep}, ::Type{U1Irrep})
+function u_plus_u_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{U1Irrep})
     return error("Not implemented")
 end
-function u_plus_u_min(T, ::Type{SU2Irrep}, ::Type{SU2Irrep})
+function u_plus_u_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const u⁺u⁻ = u_plus_u_min
 
 @doc """
-    d_plus_d_min([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    d⁺d⁻([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d_plus_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d⁺d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``c†_{1,↓}, c_{2,↓}`` that creates a spin-down particle at the first site and annihilates a spin-down particle at the second.
+Return the two-body operator ``e†_{1,↓}, e_{2,↓}`` that creates a spin-down particle at the first site and annihilates a spin-down particle at the second.
 """ d_plus_d_min
 d_plus_d_min(P::Type{<:Sector}, S::Type{<:Sector}) = d_plus_d_min(ComplexF64, P, S)
-function d_plus_d_min(T, ::Type{Trivial}, ::Type{Trivial})
-    t = two_site_operator(T, Trivial, Trivial)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    t = two_site_operator(elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(0), dual(I(0)), dual(I(1)))][2, 1, 1, 2] = 1
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][2, 1, 1, 2] = -1
@@ -295,8 +297,8 @@ function d_plus_d_min(T, ::Type{Trivial}, ::Type{Trivial})
     t[(I(0), I(1), dual(I(1)), dual(I(0)))][2, 1, 1, 2] = -1
     return t
 end
-function d_plus_d_min(T, ::Type{Trivial}, ::Type{U1Irrep})
-    t = two_site_operator(T, Trivial, U1Irrep)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
+    t = two_site_operator(elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(1, -1 // 2), I(0, 0), dual(I(0, 0)), dual(I(1, -1 // 2)))][1, 1, 1, 1] = 1
     t[(I(1, -1 // 2), I(1, 1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 1, 2] = -1
@@ -304,11 +306,11 @@ function d_plus_d_min(T, ::Type{Trivial}, ::Type{U1Irrep})
     t[(I(0, 0), I(1, 1 // 2), dual(I(1, 1 // 2)), dual(I(0, 0)))][2, 1, 1, 2] = -1
     return t
 end
-function d_plus_d_min(T, ::Type{Trivial}, ::Type{SU2Irrep})
+function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_plus_d_min(T, ::Type{U1Irrep}, ::Type{Trivial})
-    t = two_site_operator(T, U1Irrep, Trivial)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
+    t = two_site_operator(elt, U1Irrep, Trivial)
     I = sectortype(t)
     t[(I(1, 1), I(0, 0), dual(I(0, 0)), dual(I(1, 1)))][2, 1, 1, 2] = 1
     t[(I(1, 1), I(1, 1), dual(I(0, 0)), dual(I(0, 2)))][2, 1, 1, 1] = -1
@@ -316,8 +318,8 @@ function d_plus_d_min(T, ::Type{U1Irrep}, ::Type{Trivial})
     t[(I(0, 2), I(1, 1), dual(I(1, 1)), dual(I(0, 2)))][1, 1, 1, 1] = -1
     return t
 end
-function d_plus_d_min(T, ::Type{U1Irrep}, ::Type{U1Irrep})
-    t = two_site_operator(T, U1Irrep, U1Irrep)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
+    t = two_site_operator(elt, U1Irrep, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1, -1 // 2), I(0, 0, 0), dual(I(0, 0, 0)), dual(I(1, 1, -1 // 2)))] .= 1
     t[(I(1, 1, -1 // 2), I(1, 1, 1 // 2), dual(I(0, 0, 0)), dual(I(0, 2, 0)))] .= -1
@@ -325,62 +327,62 @@ function d_plus_d_min(T, ::Type{U1Irrep}, ::Type{U1Irrep})
     t[(I(0, 2, 0), I(1, 1, 1 // 2), dual(I(1, 1, 1 // 2)), dual(I(0, 2, 0)))] .= -1
     return t
 end
-function d_plus_d_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
+function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_plus_d_min(T, ::Type{SU2Irrep}, ::Type{Trivial})
+function d_plus_d_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{Trivial})
     return error("Not implemented")
 end
-function d_plus_d_min(T, ::Type{SU2Irrep}, ::Type{U1Irrep})
+function d_plus_d_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{U1Irrep})
     return error("Not implemented")
 end
-function d_plus_d_min(T, ::Type{SU2Irrep}, ::Type{SU2Irrep})
+function d_plus_d_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const d⁺d⁻ = d_plus_d_min
 
 @doc """
-    u_min_u_plus([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    u⁻u⁺([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u_min_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u⁻u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the Hermitian conjugate of `u_plus_u_min`, i.e.
-``(c†_{1,↑}, c_{2,↑})† = -c_{1,↑}, c†_{2,↑}`` (note the extra minus sign). 
+``(e†_{1,↑}, e_{2,↑})† = -e_{1,↑}, e†_{2,↑}`` (note the extra minus sign). 
 It annihilates a spin-up particle at the first site and creates a spin-up particle at the second.
 """ u_min_u_plus
 u_min_u_plus(P::Type{<:Sector}, S::Type{<:Sector}) = u_min_u_plus(ComplexF64, P, S)
-function u_min_u_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
-    return copy(adjoint(u_plus_u_min(T, particle_symmetry, spin_symmetry)))
+function u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    return copy(adjoint(u_plus_u_min(elt, particle_symmetry, spin_symmetry)))
 end
 const u⁻u⁺ = u_min_u_plus
 
 @doc """
-    d_min_d_plus([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    d⁻d⁺([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d_min_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d⁻d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the Hermitian conjugate of `d_plus_d_min`, i.e.
-``(c†_{1,↓}, c_{2,↓})† = -c_{1,↓}, c†_{2,↓}`` (note the extra minus sign). 
+``(e†_{1,↓}, e_{2,↓})† = -e_{1,↓}, e†_{2,↓}`` (note the extra minus sign). 
 It annihilates a spin-down particle at the first site and creates a spin-down particle at the second.
 """ d_min_d_plus
 d_min_d_plus(P::Type{<:Sector}, S::Type{<:Sector}) = d_min_d_plus(ComplexF64, P, S)
-function d_min_d_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
-    return copy(adjoint(d_plus_d_min(T, particle_symmetry, spin_symmetry)))
+function d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    return copy(adjoint(d_plus_d_min(elt, particle_symmetry, spin_symmetry)))
 end
 const d⁻d⁺ = d_min_d_plus
 
 @doc """
-    c_plus_c_min([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    c⁺c⁻([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e_plus_e_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e⁺e⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
 This is the sum of `u_plus_u_min` and `d_plus_d_min`.
-""" c_plus_c_min
-c_plus_c_min(P::Type{<:Sector}, S::Type{<:Sector}) = c_plus_c_min(ComplexF64, P, S)
-function c_plus_c_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
-    return u_plus_u_min(T, particle_symmetry, spin_symmetry) +
-           d_plus_d_min(T, particle_symmetry, spin_symmetry)
+""" e_plus_e_min
+e_plus_e_min(P::Type{<:Sector}, S::Type{<:Sector}) = e_plus_e_min(ComplexF64, P, S)
+function e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    return u_plus_u_min(elt, particle_symmetry, spin_symmetry) +
+           d_plus_d_min(elt, particle_symmetry, spin_symmetry)
 end
-function c_plus_c_min(T, ::Type{Trivial}, ::Type{SU2Irrep})
-    t = two_site_operator(T, Trivial, SU2Irrep)
+function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
+    t = two_site_operator(elt, Trivial, SU2Irrep)
     I = sectortype(t)
     f1 = only(fusiontrees((I(0, 0), I(1, 1 // 2)), I(1, 1 // 2)))
     f2 = only(fusiontrees((I(1, 1 // 2), I(0, 0)), I(1, 1 // 2)))
@@ -396,8 +398,8 @@ function c_plus_c_min(T, ::Type{Trivial}, ::Type{SU2Irrep})
     t[f7, f8][1, 1, 2, 1] = sqrt(2)
     return t
 end
-function c_plus_c_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    t = two_site_operator(T, U1Irrep, SU2Irrep)
+function e_plus_e_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    t = two_site_operator(elt, U1Irrep, SU2Irrep)
     I = sectortype(t)
     f1 = only(fusiontrees((I(0, 0, 0), I(1, 1, 1 // 2)), I(1, 1, 1 // 2)))
     f2 = only(fusiontrees((I(1, 1, 1 // 2), I(0, 0, 0)), I(1, 1, 1 // 2)))
@@ -413,19 +415,32 @@ function c_plus_c_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep})
     t[f7, f8] .= sqrt(2)
     return t
 end
-const c⁺c⁻ = c_plus_c_min
+const e⁺e⁻ = e_plus_e_min
 
 @doc """
-    c_min_c_plus([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    c⁻c⁺([T], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e_min_e_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e⁻e⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
 This is the sum of `u_min_u_plus` and `d_min_d_plus`.
-""" c_min_c_plus
-c_min_c_plus(P::Type{<:Sector}, S::Type{<:Sector}) = c_min_c_plus(ComplexF64, P, S)
-function c_min_c_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
-    return -copy(adjoint(c_plus_c_min(T, particle_symmetry, spin_symmetry)))
+""" e_min_e_plus
+e_min_e_plus(P::Type{<:Sector}, S::Type{<:Sector}) = e_min_e_plus(ComplexF64, P, S)
+function e_min_e_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    return -copy(adjoint(e_plus_e_min(elt, particle_symmetry, spin_symmetry)))
 end
-const c⁻c⁺ = c_min_c_plus
+const e⁻e⁺ = e_min_e_plus
+
+@doc """
+    e_hopping([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e_hop([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+
+Return the two-body operator that describes a particle that hops between the first and the second site.
+""" e_hop
+e_hopping(P::Type{<:Sector}, S::Type{<:Sector}) = e_hopping(ComplexF64, P, S)
+function e_hopping(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    return e_plus_e_min(elt, particle_symmetry, spin_symmetry) -
+           e_min_e_plus(elt, particle_symmetry, spin_symmetry)
+end
+const e_hop = e_hopping
 
 end

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -167,7 +167,8 @@ const nꜜ = d_num
 Return the one-body operator that counts the number of particles.
 """ e_num
 e_num(P::Type{<:Sector}, S::Type{<:Sector}) = e_num(ComplexF64, P, S)
-function e_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+function e_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+               spin_symmetry::Type{<:Sector})
     return u_num(elt, particle_symmetry, spin_symmetry) +
            d_num(elt, particle_symmetry, spin_symmetry)
 end
@@ -350,7 +351,8 @@ Return the Hermitian conjugate of `u_plus_u_min`, i.e.
 It annihilates a spin-up particle at the first site and creates a spin-up particle at the second.
 """ u_min_u_plus
 u_min_u_plus(P::Type{<:Sector}, S::Type{<:Sector}) = u_min_u_plus(ComplexF64, P, S)
-function u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+function u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector})
     return copy(adjoint(u_plus_u_min(elt, particle_symmetry, spin_symmetry)))
 end
 const u⁻u⁺ = u_min_u_plus
@@ -364,7 +366,8 @@ Return the Hermitian conjugate of `d_plus_d_min`, i.e.
 It annihilates a spin-down particle at the first site and creates a spin-down particle at the second.
 """ d_min_d_plus
 d_min_d_plus(P::Type{<:Sector}, S::Type{<:Sector}) = d_min_d_plus(ComplexF64, P, S)
-function d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+function d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector})
     return copy(adjoint(d_plus_d_min(elt, particle_symmetry, spin_symmetry)))
 end
 const d⁻d⁺ = d_min_d_plus
@@ -377,7 +380,8 @@ Return the two-body operator that creates a particle at the first site and annih
 This is the sum of `u_plus_u_min` and `d_plus_d_min`.
 """ e_plus_e_min
 e_plus_e_min(P::Type{<:Sector}, S::Type{<:Sector}) = e_plus_e_min(ComplexF64, P, S)
-function e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+function e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector})
     return u_plus_u_min(elt, particle_symmetry, spin_symmetry) +
            d_plus_d_min(elt, particle_symmetry, spin_symmetry)
 end
@@ -425,7 +429,8 @@ Return the two-body operator that annihilates a particle at the first site and c
 This is the sum of `u_min_u_plus` and `d_min_d_plus`.
 """ e_min_e_plus
 e_min_e_plus(P::Type{<:Sector}, S::Type{<:Sector}) = e_min_e_plus(ComplexF64, P, S)
-function e_min_e_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+function e_min_e_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector})
     return -copy(adjoint(e_plus_e_min(elt, particle_symmetry, spin_symmetry)))
 end
 const e⁻e⁺ = e_min_e_plus
@@ -437,7 +442,8 @@ const e⁻e⁺ = e_min_e_plus
 Return the two-body operator that describes a particle that hops between the first and the second site.
 """ e_hop
 e_hopping(P::Type{<:Sector}, S::Type{<:Sector}) = e_hopping(ComplexF64, P, S)
-function e_hopping(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+function e_hopping(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                   spin_symmetry::Type{<:Sector})
     return e_plus_e_min(elt, particle_symmetry, spin_symmetry) -
            e_min_e_plus(elt, particle_symmetry, spin_symmetry)
 end

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -18,7 +18,7 @@ export e_hop
 Return the local hilbert space for a Hubbard-type model with the given particle and spin symmetries.
 The possible symmetries are `Trivial`, `U1Irrep`, and `SU2Irrep`, for both particle number and spin.
 """
-function hubbard_space(::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
+function hubbard_space((::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
     return Vect[FermionParity](0 => 2, 1 => 2)
 end
 function hubbard_space(::Type{Trivial}, ::Type{U1Irrep})
@@ -63,7 +63,7 @@ end
 Return the one-body operator that counts the number of spin-up particles.
 """ u_num
 u_num(P::Type{<:Sector}, S::Type{<:Sector}) = u_num(ComplexF64, P, S)
-function u_num(elt::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
+function u_num(elt::Type{<:Number}, (::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
     t = single_site_operator(elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][1, 1] = 1
@@ -115,7 +115,7 @@ const nꜛ = u_num
 Return the one-body operator that counts the number of spin-down particles.
 """ d_num
 d_num(P::Type{<:Sector}, S::Type{<:Sector}) = d_num(ComplexF64, P, S)
-function d_num(elt::Type{<:Number}, ::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial)
+function d_num(elt::Type{<:Number}, (::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
     t = single_site_operator(elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][2, 2] = 1

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -224,7 +224,7 @@ end
 
 @doc """
     u_plus_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    u⁺d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u⁺u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↑}, e_{2,↑}`` that creates a spin-up particle at the first site and annihilates a spin-up particle at the second.
 """ u_plus_u_min

--- a/src/spinoperators.jl
+++ b/src/spinoperators.jl
@@ -5,10 +5,10 @@ using LinearAlgebra: diagind
 
 export spin_space, casimir
 export S_x, S_y, S_z, S_plus, S_min
-export S_xx, S_yy, S_zz, S_plusmin, S_minplus, S_exchange
+export S_x_S_x, S_y_S_y, S_z_S_z, S_plus_S_min, S_min_S_plus, S_exchange
 export σˣ, σʸ, σᶻ, σ⁺, σ⁻
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
-export Sˣˣ, Sʸʸ, Sᶻᶻ, S⁺⁻, S⁻⁺, SS
+export SˣSˣ, SʸSʸ, SᶻSᶻ, S⁺S⁻, S⁻S⁺, SS
 
 """
     spin_space([symmetry::Type{<:Sector}]; spin=1 // 2)
@@ -217,15 +217,15 @@ const S⁻ = S_min
 # Two site operators
 # ------------------
 @doc """
-    S_xx([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
-    Sˣˣ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    S_x_S_x([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    SˣSˣ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin x exchange operator.
-""" S_xx
-S_xx(; kwargs...) = S_xx(ComplexF64, Trivial; kwargs...)
-S_xx(elt::Type{<:Number}; kwargs...) = S_xx(elt, Trivial; kwargs...)
-S_xx(symm::Type{<:Sector}; kwargs...) = S_xx(ComplexF64, symm; kwargs...)
-function S_xx(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
+""" S_x_S_x
+S_x_S_x(; kwargs...) = S_x_S_x(ComplexF64, Trivial; kwargs...)
+S_x_S_x(elt::Type{<:Number}; kwargs...) = S_x_S_x(elt, Trivial; kwargs...)
+S_x_S_x(symm::Type{<:Sector}; kwargs...) = S_x_S_x(ComplexF64, symm; kwargs...)
+function S_x_S_x(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
     if symmetry === Trivial || symmetry === Z2Irrep
         XX = S_x(elt, symmetry; spin) ⊗ S_x(elt, symmetry; spin)
     else
@@ -233,18 +233,18 @@ function S_xx(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
     end
     return XX
 end
-const Sˣˣ = S_xx
+const SˣSˣ = S_x_S_x
 
 @doc """
-    S_yy([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
-    Sʸʸ([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    S_y_S_y([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    SʸSʸ([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin y exchange operator.
-""" S_yy
-S_yy(; kwargs...) = S_yy(ComplexF64, Trivial; kwargs...)
-S_yy(elt::Type{<:Complex}; kwargs...) = S_yy(elt, Trivial; kwargs...)
-S_yy(symm::Type{<:Sector}; kwargs...) = S_yy(ComplexF64, symm; kwargs...)
-function S_yy(elt::Type{<:Complex}, symmetry::Type{<:Sector}; spin=1 // 2)
+""" S_y_S_y
+S_y_S_y(; kwargs...) = S_y_S_y(ComplexF64, Trivial; kwargs...)
+S_y_S_y(elt::Type{<:Complex}; kwargs...) = S_y_S_y(elt, Trivial; kwargs...)
+S_y_S_y(symm::Type{<:Sector}; kwargs...) = S_y_S_y(ComplexF64, symm; kwargs...)
+function S_y_S_y(elt::Type{<:Complex}, symmetry::Type{<:Sector}; spin=1 // 2)
     if symmetry === Trivial
         YY = S_y(elt, Trivial; spin) ⊗ S_y(elt, Trivial; spin)
     else
@@ -252,18 +252,18 @@ function S_yy(elt::Type{<:Complex}, symmetry::Type{<:Sector}; spin=1 // 2)
     end
     return YY
 end
-const Sʸʸ = S_yy
+const SʸSʸ = S_y_S_y
 
 @doc """
-    S_zz([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
-    Sᶻᶻ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    S_z_S_z([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    SᶻSᶻ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin z exchange operator.
-""" S_zz
-S_zz(; kwargs...) = S_zz(ComplexF64, Trivial; kwargs...)
-S_zz(elt::Type{<:Number}; kwargs...) = S_zz(elt, Trivial; kwargs...)
-S_zz(symm::Type{<:Sector}; kwargs...) = S_zz(ComplexF64, symm; kwargs...)
-function S_zz(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
+""" S_z_S_z
+S_z_S_z(; kwargs...) = S_z_S_z(ComplexF64, Trivial; kwargs...)
+S_z_S_z(elt::Type{<:Number}; kwargs...) = S_z_S_z(elt, Trivial; kwargs...)
+S_z_S_z(symm::Type{<:Sector}; kwargs...) = S_z_S_z(ComplexF64, symm; kwargs...)
+function S_z_S_z(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
     if symmetry === Trivial || symmetry === U1Irrep
         ZZ = S_z(elt, symmetry; spin) ⊗ S_z(elt, symmetry; spin)
     elseif symmetry === Z2Irrep
@@ -279,67 +279,67 @@ function S_zz(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
     end
     return ZZ
 end
-const Sᶻᶻ = S_zz
+const SᶻSᶻ = S_z_S_z
 
 @doc """
-    S_plusmin([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
-    S⁺⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    S_plus_S_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    S⁺S⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin raising-lowering operator.
-""" S_plusmin
-S_plusmin(; kwargs...) = S_plusmin(ComplexF64, Trivial; kwargs...)
-S_plusmin(elt::Type{<:Number}; kwargs...) = S_plusmin(elt, Trivial; kwargs...)
-S_plusmin(symm::Type{<:Sector}; kwargs...) = S_plusmin(ComplexF64, symm; kwargs...)
-function S_plusmin(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
+""" S_plus_S_min
+S_plus_S_min(; kwargs...) = S_plus_S_min(ComplexF64, Trivial; kwargs...)
+S_plus_S_min(elt::Type{<:Number}; kwargs...) = S_plus_S_min(elt, Trivial; kwargs...)
+S_plus_S_min(symm::Type{<:Sector}; kwargs...) = S_plus_S_min(ComplexF64, symm; kwargs...)
+function S_plus_S_min(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
     if symmetry === Trivial
-        S⁺⁻ = S_plus(elt, symmetry; spin) ⊗ S_min(elt, symmetry; spin)
+        S⁺S⁻ = S_plus(elt, symmetry; spin) ⊗ S_min(elt, symmetry; spin)
     elseif symmetry === U1Irrep
         pspace = spin_space(U1Irrep; spin)
-        S⁺⁻ = zeros(elt, pspace ⊗ pspace ← pspace ⊗ pspace)
-        for (f₁, f₂) in fusiontrees(S⁺⁻)
+        S⁺S⁻ = zeros(elt, pspace ⊗ pspace ← pspace ⊗ pspace)
+        for (f₁, f₂) in fusiontrees(S⁺S⁻)
             if f₁.uncoupled[1].charge == f₂.uncoupled[1].charge + 1 &&
                f₁.uncoupled[2].charge == f₂.uncoupled[2].charge - 1
                 m₁, m₂ = getproperty.(f₂.uncoupled, :charge)
-                S⁺⁻[f₁, f₂] .= sqrt(casimir(spin) - m₁ * (m₁ + 1)) *
+                S⁺S⁻[f₁, f₂] .= sqrt(casimir(spin) - m₁ * (m₁ + 1)) *
                                sqrt(casimir(spin) - m₂ * (m₂ - 1))
             end
         end
     else
         throw(ArgumentError("invalid symmetry `$symmetry`"))
     end
-    return S⁺⁻
+    return S⁺S⁻
 end
-const S⁺⁻ = S_plusmin
+const S⁺S⁻ = S_plus_S_min
 
 @doc """
-    S_minplus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
-    S⁻⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    S_min_S_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    S⁻S⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin lowering-raising operator.
-""" S_minplus
-S_minplus(; kwargs...) = S_minplus(ComplexF64, Trivial; kwargs...)
-S_minplus(elt::Type{<:Number}; kwargs...) = S_minplus(elt, Trivial; kwargs...)
-S_minplus(symm::Type{<:Sector}; kwargs...) = S_minplus(ComplexF64, symm; kwargs...)
-function S_minplus(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
+""" S_min_S_plus
+S_min_S_plus(; kwargs...) = S_min_S_plus(ComplexF64, Trivial; kwargs...)
+S_min_S_plus(elt::Type{<:Number}; kwargs...) = S_min_S_plus(elt, Trivial; kwargs...)
+S_min_S_plus(symm::Type{<:Sector}; kwargs...) = S_min_S_plus(ComplexF64, symm; kwargs...)
+function S_min_S_plus(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
     if symmetry === Trivial
-        S⁻⁺ = S_min(elt, symmetry; spin) ⊗ S_plus(elt, symmetry; spin)
+        S⁻S⁺ = S_min(elt, symmetry; spin) ⊗ S_plus(elt, symmetry; spin)
     elseif symmetry === U1Irrep
         pspace = spin_space(U1Irrep; spin)
-        S⁻⁺ = zeros(elt, pspace ⊗ pspace ← pspace ⊗ pspace)
-        for (f₁, f₂) in fusiontrees(S⁻⁺)
+        S⁻S⁺ = zeros(elt, pspace ⊗ pspace ← pspace ⊗ pspace)
+        for (f₁, f₂) in fusiontrees(S⁻S⁺)
             if f₁.uncoupled[1].charge == f₂.uncoupled[1].charge - 1 &&
                f₁.uncoupled[2].charge == f₂.uncoupled[2].charge + 1
                 m₁, m₂ = getproperty.(f₂.uncoupled, :charge)
-                S⁻⁺[f₁, f₂] .= sqrt(casimir(spin) - m₁ * (m₁ - 1)) *
+                S⁻S⁺[f₁, f₂] .= sqrt(casimir(spin) - m₁ * (m₁ - 1)) *
                                sqrt(casimir(spin) - m₂ * (m₂ + 1))
             end
         end
     else
         throw(ArgumentError("invalid symmetry `$symmetry`"))
     end
-    return S⁻⁺
+    return S⁻S⁺
 end
-const S⁻⁺ = S_minplus
+const S⁻S⁺ = S_min_S_plus
 
 @doc """
     S_exchange([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
@@ -354,8 +354,8 @@ function S_exchange(symmetry::Type{<:Sector}; kwargs...)
 end
 function S_exchange(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
     if symmetry === Trivial || symmetry === U1Irrep
-        SS = (S_plusmin(elt, symmetry; spin) + S_minplus(elt, symmetry; spin)) / 2 +
-             S_zz(elt, symmetry; spin)
+        SS = (S_plus_S_min(elt, symmetry; spin) + S_min_S_plus(elt, symmetry; spin)) / 2 +
+             S_z_S_z(elt, symmetry; spin)
     elseif symmetry === SU2Irrep
         pspace = spin_space(SU2Irrep; spin)
         SS = zeros(elt, pspace ⊗ pspace ← pspace ⊗ pspace)

--- a/src/spinoperators.jl
+++ b/src/spinoperators.jl
@@ -301,7 +301,7 @@ function S_plus_S_min(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2
                f₁.uncoupled[2].charge == f₂.uncoupled[2].charge - 1
                 m₁, m₂ = getproperty.(f₂.uncoupled, :charge)
                 S⁺S⁻[f₁, f₂] .= sqrt(casimir(spin) - m₁ * (m₁ + 1)) *
-                               sqrt(casimir(spin) - m₂ * (m₂ - 1))
+                                sqrt(casimir(spin) - m₂ * (m₂ - 1))
             end
         end
     else
@@ -331,7 +331,7 @@ function S_min_S_plus(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2
                f₁.uncoupled[2].charge == f₂.uncoupled[2].charge + 1
                 m₁, m₂ = getproperty.(f₂.uncoupled, :charge)
                 S⁻S⁺[f₁, f₂] .= sqrt(casimir(spin) - m₁ * (m₁ - 1)) *
-                               sqrt(casimir(spin) - m₂ * (m₂ + 1))
+                                sqrt(casimir(spin) - m₂ * (m₂ + 1))
             end
         end
     else

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -3,19 +3,19 @@ module TJOperators
 using TensorKit
 
 export tj_space
-export c_num, u_num, d_num, c_num_hole
+export e_num, u_num, d_num, h_num
 export S_x, S_y, S_z, S_plus, S_min
 export u_plus_u_min, d_plus_d_min
 export u_min_u_plus, d_min_d_plus
 export u_min_d_min, d_min_u_min
-export c_plus_c_min, c_min_c_plus, c_singlet
-export S_plusmin, S_minplus, S_exchange
+export e_plus_e_min, e_min_e_plus, singlet_min, e_hopping
+export S_plus_S_min, S_min_S_plus, S_exchange
 
 export nꜛ, nꜜ, nʰ, n
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
 export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺, u⁻d⁻, d⁻u⁻
-export c⁺c⁻, c⁻c⁺
-export S⁻⁺, S⁺⁻
+export e⁺e⁻, e⁻e⁺, singlet⁻, e_hop
+export S⁻S⁺, S⁺S⁻
 
 """
     tj_space(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
@@ -74,10 +74,10 @@ end
 
 # Single-site operators
 # ---------------------
-function single_site_operator(T, particle_symmetry::Type{<:Sector},
+function single_site_operator(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
                               spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
     V = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
-    return zeros(T, V ← V)
+    return zeros(elt, V ← V)
 end
 
 @doc """
@@ -88,39 +88,39 @@ Return the one-body operator that counts the number of spin-up electrons.
 function u_num(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return u_num(ComplexF64, P, S; slave_fermion)
 end
-function u_num(T::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
                slave_fermion::Bool=false)
-    t = single_site_operator(T, Trivial, Trivial; slave_fermion)
+    t = single_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b), dual(I(b)))][1, 1] = 1
     return t
 end
-function u_num(T, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = single_site_operator(T, Trivial, U1Irrep; slave_fermion)
+function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1 // 2), dual(I(b, 1 // 2)))][1, 1] = 1
     return t
 end
-function u_num(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_num(T, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = single_site_operator(T, U1Irrep, Trivial; slave_fermion)
+function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1), dual(I(b, 1)))][1, 1] = 1
     return t
 end
-function u_num(T, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = single_site_operator(T, U1Irrep, U1Irrep; slave_fermion)
+function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1, 1 // 2), dual(I(b, 1, 1 // 2)))] .= 1
     return t
 end
-function u_num(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const nꜛ = u_num
@@ -133,58 +133,58 @@ Return the one-body operator that counts the number of spin-down electrons.
 function d_num(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return d_num(ComplexF64, P, S; slave_fermion)
 end
-function d_num(T::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
                slave_fermion::Bool=false)
-    t = single_site_operator(T, Trivial, Trivial; slave_fermion)
+    t = single_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b), dual(I(b)))][2, 2] = 1
     return t
 end
-function d_num(T, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = single_site_operator(T, Trivial, U1Irrep; slave_fermion)
+function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, -1 // 2), dual(I(b, -1 // 2)))][1, 1] = 1
     return t
 end
-function d_num(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_num(T, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = single_site_operator(T, U1Irrep, Trivial; slave_fermion)
+function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1), dual(I(b, 1)))][2, 2] = 1
     return t
 end
-function d_num(T, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = single_site_operator(T, U1Irrep, U1Irrep; slave_fermion)
+function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1, -1 // 2), dual(I(b, 1, -1 // 2)))] .= 1
     return t
 end
-function d_num(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const nꜜ = d_num
 
 @doc """
-    c_num(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    e_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body operator that counts the number of particles.
-""" c_num
-function c_num(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
-    return c_num(ComplexF64, P, S; slave_fermion)
+""" e_num
+function e_num(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return e_num(ComplexF64, P, S; slave_fermion)
 end
-function c_num(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function e_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                slave_fermion::Bool=false)
-    return u_num(T, particle_symmetry, spin_symmetry; slave_fermion) +
-           d_num(T, particle_symmetry, spin_symmetry; slave_fermion)
+    return u_num(elt, particle_symmetry, spin_symmetry; slave_fermion) +
+           d_num(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
-function c_num(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
-    t = single_site_operator(T, Trivial, SU2Irrep; slave_fermion)
+function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, Trivial, SU2Irrep; slave_fermion)
     I = sectortype(t)
     if slave_fermion
         block(t, I(0, 1 // 2))[1, 1] = 1
@@ -193,8 +193,8 @@ function c_num(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     end
     return t
 end
-function c_num(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
-    t = single_site_operator(T, U1Irrep, SU2Irrep; slave_fermion)
+function e_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, U1Irrep, SU2Irrep; slave_fermion)
     I = sectortype(t)
     if slave_fermion
         block(t, I(0, 1, 1 // 2))[1, 1] = 1
@@ -203,25 +203,25 @@ function c_num(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     end
     return t
 end
-const n = c_num
+const n = e_num
 
 @doc """
-    c_num_hole(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    h_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body operator that counts the number of holes.
-""" c_num_hole
-function c_num_hole(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
-    return c_num_hole(ComplexF64, P, S; slave_fermion)
+""" h_num
+function h_num(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return h_num(ComplexF64, P, S; slave_fermion)
 end
-function c_num_hole(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function h_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                     slave_fermion::Bool=false)
     iden = TensorKit.id(tj_space(particle_symmetry, spin_symmetry; slave_fermion))
-    return iden - c_num(T, particle_symmetry, spin_symmetry; slave_fermion)
+    return iden - e_num(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
-const nʰ = c_num_hole
+const nʰ = h_num
 
 @doc """
-    S_x(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    S_x(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body spin-1/2 x-operator on the electrons.
 """ S_x
@@ -229,16 +229,16 @@ function S_x(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial;
              slave_fermion::Bool=false)
     return S_x(ComplexF64, P, S; slave_fermion)
 end
-function S_x(T::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = single_site_operator(T, Trivial, Trivial; slave_fermion)
+function S_x(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b), dual(I(b)))][1, 2] = 0.5
     t[(I(b), dual(I(b)))][2, 1] = 0.5
     return t
 end
-function S_x(T::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = single_site_operator(T, U1Irrep, Trivial; slave_fermion)
+function S_x(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1), dual(I(b, 1)))][1, 2] = 0.5
@@ -248,7 +248,7 @@ end
 const Sˣ = S_x
 
 @doc """
-    S_y(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    S_y(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body spin-1/2 x-operator on the electrons (only defined for `Trivial` symmetry). 
 """ S_y
@@ -256,16 +256,16 @@ function S_y(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial;
              slave_fermion::Bool=false)
     return S_y(ComplexF64, P, S; slave_fermion)
 end
-function S_y(T::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = single_site_operator(T, Trivial, Trivial; slave_fermion)
+function S_y(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b), dual(I(b)))][1, 2] = -0.5im
     t[(I(b), dual(I(b)))][2, 1] = 0.5im
     return t
 end
-function S_y(T::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = single_site_operator(T, U1Irrep, Trivial; slave_fermion)
+function S_y(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1), dual(I(b, 1)))][1, 2] = -0.5im
@@ -275,7 +275,7 @@ end
 const Sʸ = S_y
 
 @doc """
-    S_z(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    S_z(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body spin-1/2 z-operator on the electrons. 
 """ S_z
@@ -283,32 +283,32 @@ function S_z(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial;
              slave_fermion::Bool=false)
     return S_z(ComplexF64, P, S; slave_fermion)
 end
-function S_z(T::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = single_site_operator(T, Trivial, Trivial; slave_fermion)
+function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b), dual(I(b)))][1, 1] = 0.5
     t[(I(b), dual(I(b)))][2, 2] = -0.5
     return t
 end
-function S_z(T::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = single_site_operator(T, Trivial, U1Irrep; slave_fermion)
+function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1 // 2), dual(I(b, 1 // 2)))] .= 0.5
     t[(I(b, -1 // 2), dual(I(b, -1 // 2)))] .= -0.5
     return t
 end
-function S_z(T::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = single_site_operator(T, U1Irrep, Trivial; slave_fermion)
+function S_z(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1), dual(I(b, 1)))][1, 1] = 0.5
     t[(I(b, 1), dual(I(b, 1)))][2, 2] = -0.5
     return t
 end
-function S_z(T::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = single_site_operator(T, U1Irrep, U1Irrep; slave_fermion)
+function S_z(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = single_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1, 1 // 2), dual(I(b, 1, 1 // 2)))] .= 0.5
@@ -318,45 +318,45 @@ end
 const Sᶻ = S_z
 
 @doc """
-    S_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the spin-plus operator.
 """ S_plus
 function S_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_plus(ComplexF64, P, S; slave_fermion)
 end
-function S_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                 slave_fermion::Bool=false)
-    return S_x(T, particle_symmetry, spin_symmetry; slave_fermion) +
-           1im * S_y(T, particle_symmetry, spin_symmetry; slave_fermion)
+    return S_x(elt::Type{<:Number}, particle_symmetry, spin_symmetry; slave_fermion) +
+           1im * S_y(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
 const S⁺ = S_plus
 
 @doc """
-    S_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the spin-minus operator.
 """ S_min
 function S_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_min(ComplexF64, P, S; slave_fermion)
 end
-function S_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                slave_fermion::Bool=false)
-    return S_x(T, particle_symmetry, spin_symmetry; slave_fermion) -
-           1im * S_y(T, particle_symmetry, spin_symmetry; slave_fermion)
+    return S_x(elt, particle_symmetry, spin_symmetry; slave_fermion) -
+           1im * S_y(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
 const S⁻ = S_min
 
 # Two site operators
 # ------------------
-function two_site_operator(T, particle_symmetry::Type{<:Sector},
+function two_site_operator(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
                            spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
     V = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
-    return zeros(T, V ⊗ V ← V ⊗ V)
+    return zeros(elt, V ⊗ V ← V ⊗ V)
 end
 
 @doc """
-    u_plus_u_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    u_plus_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e†_{1,↑}, e_{2,↑}`` that creates a spin-up electron at the first site and annihilates a spin-up electron at the second.
 The only nonzero matrix element corresponds to `|↑0⟩ <-- |0↑⟩`.
@@ -364,8 +364,8 @@ The only nonzero matrix element corresponds to `|↑0⟩ <-- |0↑⟩`.
 function u_plus_u_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return u_plus_u_min(ComplexF64, P, S; slave_fermion)
 end
-function u_plus_u_min(T, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, Trivial; slave_fermion)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     #= The extra minus sign in slave-fermion basis:
@@ -378,37 +378,37 @@ function u_plus_u_min(T, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=f
     t[(I(b), I(h), dual(I(h)), dual(I(b)))][1, 1, 1, 1] = sgn * 1
     return t
 end
-function u_plus_u_min(T, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, U1Irrep; slave_fermion)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1 // 2), I(h, 0), dual(I(h, 0)), dual(I(b, 1 // 2)))] .= sgn * 1
     return t
 end
-function u_plus_u_min(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_plus_u_min(T, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = two_site_operator(T, U1Irrep, Trivial; slave_fermion)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1), I(h, 0), dual(I(h, 0)), dual(I(b, 1)))][1, 1, 1, 1] = sgn * 1
     return t
 end
-function u_plus_u_min(T, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, U1Irrep, U1Irrep; slave_fermion)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1, 1 // 2), I(h, 0, 0), dual(I(h, 0, 0)), dual(I(b, 1, 1 // 2)))] .= sgn * 1
     return t
 end
-function u_plus_u_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const u⁺u⁻ = u_plus_u_min
 
 @doc """
-    d_plus_d_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    d_plus_d_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e†_{1,↓}, e_{2,↓}`` that creates a spin-down electron at the first site and annihilates a spin-down electron at the second.
 The only nonzero matrix element corresponds to `|↓0⟩ <-- |0↓⟩`.
@@ -416,44 +416,44 @@ The only nonzero matrix element corresponds to `|↓0⟩ <-- |0↓⟩`.
 function d_plus_d_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return d_plus_d_min(ComplexF64, P, S; slave_fermion)
 end
-function d_plus_d_min(T, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, Trivial; slave_fermion)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b), I(h), dual(I(h)), dual(I(b)))][2, 1, 1, 2] = sgn * 1
     return t
 end
-function d_plus_d_min(T, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, U1Irrep; slave_fermion)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt::Type{<:Number}, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, -1 // 2), I(h, 0), dual(I(h, 0)), dual(I(b, -1 // 2)))] .= sgn * 1
     return t
 end
-function d_plus_d_min(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_plus_d_min(T, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = two_site_operator(T, U1Irrep, Trivial; slave_fermion)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1), I(h, 0), dual(I(h, 0)), dual(I(b, 1)))][2, 1, 1, 2] = sgn * 1
     return t
 end
-function d_plus_d_min(T, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, U1Irrep, U1Irrep; slave_fermion)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1, -1 // 2), I(h, 0, 0), dual(I(h, 0, 0)), dual(I(b, 1, -1 // 2)))] .= sgn * 1
     return t
 end
-function d_plus_d_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const d⁺d⁻ = d_plus_d_min
 
 @doc """
-    u_min_u_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the Hermitian conjugate of `u_plus_u_min`, i.e.
 ``(e†_{1,↑}, e_{2,↑})† = -e_{1,↑}, e†_{2,↑}`` (note the extra minus sign). 
@@ -463,14 +463,14 @@ The only nonzero matrix element corresponds to `|0↑⟩ <-- |↑0⟩`.
 function u_min_u_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return u_min_u_plus(ComplexF64, P, S; slave_fermion)
 end
-function u_min_u_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
-    return copy(adjoint(u_plus_u_min(T, particle_symmetry, spin_symmetry; slave_fermion)))
+    return copy(adjoint(u_plus_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
 const u⁻u⁺ = u_min_u_plus
 
 @doc """
-    d_min_d_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the Hermitian conjugate of `d_plus_d_min`, i.e.
 ``(e†_{1,↓}, e_{2,↓})† = -e_{1,↓}, e†_{2,↓}`` (note the extra minus sign). 
@@ -480,14 +480,14 @@ The only nonzero matrix element corresponds to `|0↓⟩ <-- |↓0⟩`.
 function d_min_d_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return d_min_d_plus(ComplexF64, P, S; slave_fermion)
 end
-function d_min_d_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
-    return copy(adjoint(d_plus_d_min(T, particle_symmetry, spin_symmetry; slave_fermion)))
+    return copy(adjoint(d_plus_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
 const d⁻d⁺ = d_min_d_plus
 
 @doc """
-    u_min_d_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    u_min_d_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up particle at the first site and a spin-down particle at the second site.
 The only nonzero matrix element corresponds to `|00⟩ <-- |↑↓⟩`.
@@ -495,33 +495,33 @@ The only nonzero matrix element corresponds to `|00⟩ <-- |↑↓⟩`.
 function u_min_d_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return u_min_d_min(ComplexF64, P, S; slave_fermion)
 end
-function u_min_d_min(T, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, Trivial; slave_fermion)
+function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(h), I(h), dual(I(b)), dual(I(b)))][1, 1, 1, 2] = -sgn * 1
     return t
 end
-function u_min_d_min(T, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, U1Irrep; slave_fermion)
+function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(h, 0), I(h, 0), dual(I(b, 1 // 2)), dual(I(b, -1 // 2)))] .= -sgn * 1
     return t
 end
-function u_min_d_min(T, ::Type{U1Irrep}, ::Type{<:Sector}; slave_fermion::Bool=false)
+function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector}; slave_fermion::Bool=false)
     throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry"))
 end
-function u_min_d_min(T, ::Type{<:Sector}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`u_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_min_d_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` spin symmetry"))
 end
 const u⁻d⁻ = u_min_d_min
 
 @doc """
-    d_min_u_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    d_min_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down particle at the first site and a spin-up particle at the second site.
 The only nonzero matrix element corresponds to `|00⟩ <-- |↓↑⟩`.
@@ -529,47 +529,47 @@ The only nonzero matrix element corresponds to `|00⟩ <-- |↓↑⟩`.
 function d_min_u_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return d_min_u_min(ComplexF64, P, S; slave_fermion)
 end
-function d_min_u_min(T, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, Trivial; slave_fermion)
+function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(h), I(h), dual(I(b)), dual(I(b)))][1, 1, 2, 1] = -sgn * 1
     return t
 end
-function d_min_u_min(T, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, U1Irrep; slave_fermion)
+function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(h, 0), I(h, 0), dual(I(b, -1 // 2)), dual(I(b, 1 // 2)))] .= -sgn * 1
     return t
 end
-function d_min_u_min(T, ::Type{U1Irrep}, ::Type{<:Sector}; slave_fermion::Bool=false)
+function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector}; slave_fermion::Bool=false)
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry"))
 end
-function d_min_u_min(T, ::Type{<:Sector}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`d_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_min_u_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
 
 @doc """
-    c_plus_c_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
 This is the sum of `u_plus_u_min` and `d_plus_d_min`.
-""" c_plus_c_min
-function c_plus_c_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
-    return c_plus_c_min(ComplexF64, P, S; slave_fermion)
+""" e_plus_e_min
+function e_plus_e_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return e_plus_e_min(ComplexF64, P, S; slave_fermion)
 end
-function c_plus_c_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
-    return u_plus_u_min(T, particle_symmetry, spin_symmetry; slave_fermion) +
-           d_plus_d_min(T, particle_symmetry, spin_symmetry; slave_fermion)
+    return u_plus_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion) +
+           d_plus_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
-function c_plus_c_min(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, SU2Irrep; slave_fermion)
+function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, SU2Irrep; slave_fermion)
     I = sectortype(t)
     if slave_fermion
         f1 = only(fusiontrees((I(1, 0), I(0, 1 // 2)), I(1, 1 // 2)))
@@ -582,8 +582,8 @@ function c_plus_c_min(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=
     end
     return t
 end
-function c_plus_c_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, U1Irrep, SU2Irrep; slave_fermion)
+function e_plus_e_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, U1Irrep, SU2Irrep; slave_fermion)
     I = sectortype(t)
     if slave_fermion
         f1 = only(fusiontrees((I(1, 0, 0), I(0, 1, 1 // 2)), I(1, 1, 1 // 2)))
@@ -597,109 +597,126 @@ function c_plus_c_min(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=
     return t
 end
 
-const c⁺c⁻ = c_plus_c_min
+const e⁺e⁻ = e_plus_e_min
 
 @doc """
-    c_min_c_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    e_min_e_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
 This is the sum of `u_min_u_plus` and `d_min_d_plus`.
-""" c_min_c_plus
-function c_min_c_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
-    return c_min_c_plus(ComplexF64, P, S; slave_fermion)
+""" e_min_e_plus
+function e_min_e_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return e_min_e_plus(ComplexF64, P, S; slave_fermion)
 end
-function c_min_c_plus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function e_min_e_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
-    return -copy(adjoint(c_plus_c_min(T, particle_symmetry, spin_symmetry; slave_fermion)))
+    return -copy(adjoint(e_plus_e_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
-const c⁻c⁺ = c_min_c_plus
+const e⁻e⁺ = e_min_e_plus
 
 @doc """
-    c_singlet(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    singlet_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body singlet operator ``(e_{1,↓} e_{2,↑} - e_{1,↓} e_{2,↑}) / sqrt(2)``.
-""" c_singlet
-function c_singlet(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
-    return c_singlet(ComplexF64, P, S; slave_fermion)
+""" singlet_min
+function singlet_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return singlet_min(ComplexF64, P, S; slave_fermion)
 end
-function c_singlet(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function singlet_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                    slave_fermion::Bool=false)
-    return (u_min_d_min(T, particle_symmetry, spin_symmetry; slave_fermion) -
-            d_min_u_min(T, particle_symmetry, spin_symmetry; slave_fermion)) / sqrt(2)
+    return (u_min_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion) -
+            d_min_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)) / sqrt(2)
 end
+const singlet⁻ = singlet_min
 
 @doc """
-    S_plusmin(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    e_hopping([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    e_hop([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator that describes a particle that hops between the first and the second site.
+""" e_hopping
+function e_hopping(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return e_hopping(ComplexF64, P, S; slave_fermion)
+end
+function e_hopping(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+               slave_fermion::Bool=false)
+    return e_plus_e_min(elt, particle_symmetry, spin_symmetry; slave_fermion) -
+           e_min_e_plus(elt, particle_symmetry, spin_symmetry; slave_fermion)
+end
+const e_hop = e_hopping
+
+@doc """
+    S_plus_S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator S⁺S⁻.
 The only nonzero matrix element corresponds to `|↑↓⟩ <-- |↓↑⟩`.
-""" S_plusmin
-function S_plusmin(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
-    return S_plusmin(ComplexF64, P, S; slave_fermion)
+""" S_plus_S_min
+function S_plus_S_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return S_plus_S_min(ComplexF64, P, S; slave_fermion)
 end
-function S_plusmin(T, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, Trivial; slave_fermion)
+function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b), I(b), dual(I(b)), dual(I(b)))][1, 2, 2, 1] = 1
     return t
 end
-function S_plusmin(T, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, U1Irrep; slave_fermion)
+function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1 // 2), I(b, -1 // 2), dual(I(b, -1 // 2)), dual(I(b, 1 // 2)))] .= 1
     return t
 end
-function S_plusmin(T, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
-    t = two_site_operator(T, U1Irrep, Trivial; slave_fermion)
+function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1), I(b, 1), dual(I(b, 1)), dual(I(b, 1)))][1, 2, 2, 1] = 1
     return t
 end
-function S_plusmin(T, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, U1Irrep, U1Irrep; slave_fermion)
+function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1, 1 // 2), I(b, 1, -1 // 2), dual(I(b, 1, -1 // 2)), dual(I(b, 1, 1 // 2)))] .= 1
     return t
 end
-const S⁺⁻ = S_plusmin
+const S⁺S⁻ = S_plus_S_min
 
 @doc """
-    S_minplus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    S_min_S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator S⁻S⁺.
 The only nonzero matrix element corresponds to `|↓↑⟩ <-- |↑↓⟩`.
-""" S_minplus
-function S_minplus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
-    return S_minplus(ComplexF64, P, S; slave_fermion)
+""" S_min_S_plus
+function S_min_S_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return S_min_S_plus(ComplexF64, P, S; slave_fermion)
 end
-function S_minplus(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function S_min_S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                    slave_fermion::Bool=false)
-    return copy(adjoint(S_plusmin(T, particle_symmetry, spin_symmetry; slave_fermion)))
+    return copy(adjoint(S_plus_S_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
-const S⁻⁺ = S_minplus
+const S⁻S⁺ = S_min_S_plus
 
 @doc """
-    S_exchange(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    S_exchange(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the spin exchange operator S⋅S.
 """ S_exchange
 function S_exchange(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_exchange(ComplexF64, P, S; slave_fermion)
 end
-function S_exchange(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function S_exchange(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
                     slave_fermion::Bool=false)
-    Sz = S_z(T, particle_symmetry, spin_symmetry; slave_fermion)
-    return (1 / 2) * (S_plusmin(T, particle_symmetry, spin_symmetry; slave_fermion)
+    Sz = S_z(elt, particle_symmetry, spin_symmetry; slave_fermion)
+    return (1 / 2) * (S_plus_S_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
                       +
-                      S_minplus(T, particle_symmetry, spin_symmetry; slave_fermion)) +
+                      S_min_S_plus(elt, particle_symmetry, spin_symmetry; slave_fermion)) +
            Sz ⊗ Sz
 end
-function S_exchange(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, Trivial, SU2Irrep; slave_fermion)
+function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, SU2Irrep; slave_fermion)
 
     for (s, f) in fusiontrees(t)
         l3 = f.uncoupled[1][2].j
@@ -709,8 +726,8 @@ function S_exchange(T, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=fa
     end
     return t
 end
-function S_exchange(T, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
-    t = two_site_operator(T, U1Irrep, SU2Irrep; slave_fermion)
+function S_exchange(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+    t = two_site_operator(elt, U1Irrep, SU2Irrep; slave_fermion)
 
     for (s, f) in fusiontrees(t)
         l3 = f.uncoupled[1][3].j

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -32,7 +32,7 @@ Setting `slave_fermion = true` switches to the slave-fermion basis.
 - basis states for `slave_fermion = true`: (c_σ = h† b_σ; holon h is fermionic, spinon b_σ is bosonic): 
     |0⟩ = h†|vac⟩, |↑⟩ = (b↑)†|vac⟩, |↓⟩ = (b↓)†|vac⟩
 """
-function tj_space((::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial;
+function tj_space(::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial;
                   slave_fermion::Bool=false)
     return slave_fermion ? Vect[FermionParity](0 => 2, 1 => 1) :
            Vect[FermionParity](0 => 1, 1 => 2)

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -32,7 +32,7 @@ Setting `slave_fermion = true` switches to the slave-fermion basis.
 - basis states for `slave_fermion = true`: (c_σ = h† b_σ; holon h is fermionic, spinon b_σ is bosonic): 
     |0⟩ = h†|vac⟩, |↑⟩ = (b↑)†|vac⟩, |↓⟩ = (b↓)†|vac⟩
 """
-function tj_space(::Type{Trivial}=Trivial, ::Type{Trivial}=Trivial;
+function tj_space((::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial;
                   slave_fermion::Bool=false)
     return slave_fermion ? Vect[FermionParity](0 => 2, 1 => 1) :
            Vect[FermionParity](0 => 1, 1 => 2)

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -82,6 +82,7 @@ end
 
 @doc """
     u_num(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    nꜛ(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the one-body operator that counts the number of spin-up electrons.
 """ u_num
@@ -132,6 +133,7 @@ const nꜛ = u_num
 
 @doc """
     d_num(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    nꜜ(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body operator that counts the number of spin-down electrons.
 """ d_num
@@ -182,6 +184,7 @@ const nꜜ = d_num
 
 @doc """
     e_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    n(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body operator that counts the number of particles.
 """ e_num
@@ -220,6 +223,7 @@ const n = e_num
 
 @doc """
     h_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    nʰ(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body operator that counts the number of holes.
 """ h_num
@@ -236,6 +240,7 @@ const nʰ = h_num
 
 @doc """
     S_x(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    Sˣ(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body spin-1/2 x-operator on the electrons.
 """ S_x
@@ -265,6 +270,7 @@ const Sˣ = S_x
 
 @doc """
     S_y(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    Sʸ(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body spin-1/2 x-operator on the electrons (only defined for `Trivial` symmetry). 
 """ S_y
@@ -294,6 +300,7 @@ const Sʸ = S_y
 
 @doc """
     S_z(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    Sᶻ(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the one-body spin-1/2 z-operator on the electrons. 
 """ S_z
@@ -341,6 +348,7 @@ const Sᶻ = S_z
 
 @doc """
     S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    S⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the spin-plus operator.
 """ S_plus
@@ -357,6 +365,7 @@ const S⁺ = S_plus
 
 @doc """
     S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    S⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
 Return the spin-minus operator.
 """ S_min
@@ -381,6 +390,7 @@ end
 
 @doc """
     u_plus_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    u⁺u⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e†_{1,↑}, e_{2,↑}`` that creates a spin-up electron at the first site and annihilates a spin-up electron at the second.
 The only nonzero matrix element corresponds to `|↑0⟩ <-- |0↑⟩`.
@@ -439,6 +449,7 @@ const u⁺u⁻ = u_plus_u_min
 
 @doc """
     d_plus_d_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    d⁺d⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e†_{1,↓}, e_{2,↓}`` that creates a spin-down electron at the first site and annihilates a spin-down electron at the second.
 The only nonzero matrix element corresponds to `|↓0⟩ <-- |0↓⟩`.
@@ -490,6 +501,7 @@ const d⁺d⁻ = d_plus_d_min
 
 @doc """
     u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    u⁻u⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the Hermitian conjugate of `u_plus_u_min`, i.e.
 ``(e†_{1,↑}, e_{2,↑})† = -e_{1,↑}, e†_{2,↑}`` (note the extra minus sign). 
@@ -508,6 +520,7 @@ const u⁻u⁺ = u_min_u_plus
 
 @doc """
     d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    d⁻d⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the Hermitian conjugate of `d_plus_d_min`, i.e.
 ``(e†_{1,↓}, e_{2,↓})† = -e_{1,↓}, e†_{2,↓}`` (note the extra minus sign). 
@@ -526,6 +539,7 @@ const d⁻d⁺ = d_min_d_plus
 
 @doc """
     u_min_d_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    u⁻d⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up particle at the first site and a spin-down particle at the second site.
 The only nonzero matrix element corresponds to `|00⟩ <-- |↑↓⟩`.
@@ -565,6 +579,7 @@ const u⁻d⁻ = u_min_d_min
 
 @doc """
     d_min_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    d⁻u⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down particle at the first site and a spin-up particle at the second site.
 The only nonzero matrix element corresponds to `|00⟩ <-- |↓↑⟩`.
@@ -604,6 +619,7 @@ const d⁻u⁻ = d_min_u_min
 
 @doc """
     e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    e⁺e⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
 This is the sum of `u_plus_u_min` and `d_plus_d_min`.
@@ -652,6 +668,7 @@ const e⁺e⁻ = e_plus_e_min
 
 @doc """
     e_min_e_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    e⁻e⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
 This is the sum of `u_min_u_plus` and `d_min_d_plus`.
@@ -668,6 +685,7 @@ const e⁻e⁺ = e_min_e_plus
 
 @doc """
     singlet_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    singlet⁻(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body singlet operator ``(e_{1,↓} e_{2,↑} - e_{1,↓} e_{2,↑}) / sqrt(2)``.
 """ singlet_min
@@ -701,6 +719,7 @@ const e_hop = e_hopping
 
 @doc """
     S_plus_S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    S⁺S⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator S⁺S⁻.
 The only nonzero matrix element corresponds to `|↑↓⟩ <-- |↓↑⟩`.
@@ -744,6 +763,7 @@ const S⁺S⁻ = S_plus_S_min
 
 @doc """
     S_min_S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    S⁻S⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator S⁻S⁺.
 The only nonzero matrix element corresponds to `|↓↑⟩ <-- |↑↓⟩`.

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -514,7 +514,7 @@ end
 function u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
                       spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
-    return copy(adjoint(u_plus_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
+    return -copy(adjoint(u_plus_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
 const u⁻u⁺ = u_min_u_plus
 
@@ -533,7 +533,7 @@ end
 function d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
                       spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
-    return copy(adjoint(d_plus_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
+    return -copy(adjoint(d_plus_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
 const d⁻d⁺ = d_min_d_plus
 

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -684,8 +684,8 @@ end
 const e⁻e⁺ = e_min_e_plus
 
 @doc """
-    singlet_min(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
-    singlet⁻(T, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    singlet_min(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    singlet⁻(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body singlet operator ``(e_{1,↓} e_{2,↑} - e_{1,↓} e_{2,↑}) / sqrt(2)``.
 """ singlet_min

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -96,31 +96,36 @@ function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
     t[(I(b), dual(I(b)))][1, 1] = 1
     return t
 end
-function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep};
+               slave_fermion::Bool=false)
     t = single_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1 // 2), dual(I(b, 1 // 2)))][1, 1] = 1
     return t
 end
-function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep};
+               slave_fermion::Bool=false)
     throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
+               slave_fermion::Bool=false)
     t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1), dual(I(b, 1)))][1, 1] = 1
     return t
 end
-function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep};
+               slave_fermion::Bool=false)
     t = single_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1, 1 // 2), dual(I(b, 1, 1 // 2)))] .= 1
     return t
 end
-function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+               slave_fermion::Bool=false)
     throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const nꜛ = u_num
@@ -141,31 +146,36 @@ function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
     t[(I(b), dual(I(b)))][2, 2] = 1
     return t
 end
-function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep};
+               slave_fermion::Bool=false)
     t = single_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, -1 // 2), dual(I(b, -1 // 2)))][1, 1] = 1
     return t
 end
-function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep};
+               slave_fermion::Bool=false)
     throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
+               slave_fermion::Bool=false)
     t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1), dual(I(b, 1)))][2, 2] = 1
     return t
 end
-function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep};
+               slave_fermion::Bool=false)
     t = single_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1, -1 // 2), dual(I(b, 1, -1 // 2)))] .= 1
     return t
 end
-function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+               slave_fermion::Bool=false)
     throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const nꜜ = d_num
@@ -178,12 +188,14 @@ Return the one-body operator that counts the number of particles.
 function e_num(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return e_num(ComplexF64, P, S; slave_fermion)
 end
-function e_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function e_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+               spin_symmetry::Type{<:Sector};
                slave_fermion::Bool=false)
     return u_num(elt, particle_symmetry, spin_symmetry; slave_fermion) +
            d_num(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
-function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep};
+               slave_fermion::Bool=false)
     t = single_site_operator(elt, Trivial, SU2Irrep; slave_fermion)
     I = sectortype(t)
     if slave_fermion
@@ -193,7 +205,8 @@ function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fer
     end
     return t
 end
-function e_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function e_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+               slave_fermion::Bool=false)
     t = single_site_operator(elt, U1Irrep, SU2Irrep; slave_fermion)
     I = sectortype(t)
     if slave_fermion
@@ -213,8 +226,9 @@ Return the one-body operator that counts the number of holes.
 function h_num(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return h_num(ComplexF64, P, S; slave_fermion)
 end
-function h_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
-                    slave_fermion::Bool=false)
+function h_num(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+               spin_symmetry::Type{<:Sector};
+               slave_fermion::Bool=false)
     iden = TensorKit.id(tj_space(particle_symmetry, spin_symmetry; slave_fermion))
     return iden - e_num(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
@@ -229,7 +243,8 @@ function S_x(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial;
              slave_fermion::Bool=false)
     return S_x(ComplexF64, P, S; slave_fermion)
 end
-function S_x(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+function S_x(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+             slave_fermion::Bool=false)
     t = single_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
@@ -237,7 +252,8 @@ function S_x(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermio
     t[(I(b), dual(I(b)))][2, 1] = 0.5
     return t
 end
-function S_x(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+function S_x(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
+             slave_fermion::Bool=false)
     t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
@@ -256,7 +272,8 @@ function S_y(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial;
              slave_fermion::Bool=false)
     return S_y(ComplexF64, P, S; slave_fermion)
 end
-function S_y(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+function S_y(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+             slave_fermion::Bool=false)
     t = single_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
@@ -264,7 +281,8 @@ function S_y(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermio
     t[(I(b), dual(I(b)))][2, 1] = 0.5im
     return t
 end
-function S_y(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+function S_y(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
+             slave_fermion::Bool=false)
     t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
@@ -283,7 +301,8 @@ function S_z(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial;
              slave_fermion::Bool=false)
     return S_z(ComplexF64, P, S; slave_fermion)
 end
-function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+             slave_fermion::Bool=false)
     t = single_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
@@ -291,7 +310,8 @@ function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermio
     t[(I(b), dual(I(b)))][2, 2] = -0.5
     return t
 end
-function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep};
+             slave_fermion::Bool=false)
     t = single_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
@@ -299,7 +319,8 @@ function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermio
     t[(I(b, -1 // 2), dual(I(b, -1 // 2)))] .= -0.5
     return t
 end
-function S_z(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+function S_z(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
+             slave_fermion::Bool=false)
     t = single_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
@@ -307,7 +328,8 @@ function S_z(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermio
     t[(I(b, 1), dual(I(b, 1)))][2, 2] = -0.5
     return t
 end
-function S_z(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function S_z(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep};
+             slave_fermion::Bool=false)
     t = single_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
@@ -325,7 +347,8 @@ Return the spin-plus operator.
 function S_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_plus(ComplexF64, P, S; slave_fermion)
 end
-function S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                spin_symmetry::Type{<:Sector};
                 slave_fermion::Bool=false)
     return S_x(elt::Type{<:Number}, particle_symmetry, spin_symmetry; slave_fermion) +
            1im * S_y(elt, particle_symmetry, spin_symmetry; slave_fermion)
@@ -340,7 +363,8 @@ Return the spin-minus operator.
 function S_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_min(ComplexF64, P, S; slave_fermion)
 end
-function S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+               spin_symmetry::Type{<:Sector};
                slave_fermion::Bool=false)
     return S_x(elt, particle_symmetry, spin_symmetry; slave_fermion) -
            1im * S_y(elt, particle_symmetry, spin_symmetry; slave_fermion)
@@ -364,7 +388,8 @@ The only nonzero matrix element corresponds to `|↑0⟩ <-- |0↑⟩`.
 function u_plus_u_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return u_plus_u_min(ComplexF64, P, S; slave_fermion)
 end
-function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
@@ -378,31 +403,36 @@ function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; sla
     t[(I(b), I(h), dual(I(h)), dual(I(b)))][1, 1, 1, 1] = sgn * 1
     return t
 end
-function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1 // 2), I(h, 0), dual(I(h, 0)), dual(I(b, 1 // 2)))] .= sgn * 1
     return t
 end
-function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep};
+                      slave_fermion::Bool=false)
     throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1), I(h, 0), dual(I(h, 0)), dual(I(b, 1)))][1, 1, 1, 1] = sgn * 1
     return t
 end
-function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1, 1 // 2), I(h, 0, 0), dual(I(h, 0, 0)), dual(I(b, 1, 1 // 2)))] .= sgn * 1
     return t
 end
-function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                      slave_fermion::Bool=false)
     throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const u⁺u⁻ = u_plus_u_min
@@ -416,38 +446,44 @@ The only nonzero matrix element corresponds to `|↓0⟩ <-- |0↓⟩`.
 function d_plus_d_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return d_plus_d_min(ComplexF64, P, S; slave_fermion)
 end
-function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b), I(h), dual(I(h)), dual(I(b)))][2, 1, 1, 2] = sgn * 1
     return t
 end
-function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt::Type{<:Number}, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, -1 // 2), I(h, 0), dual(I(h, 0)), dual(I(b, -1 // 2)))] .= sgn * 1
     return t
 end
-function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep};
+                      slave_fermion::Bool=false)
     throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1), I(h, 0), dual(I(h, 0)), dual(I(b, 1)))][2, 1, 1, 2] = sgn * 1
     return t
 end
-function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(b, 1, -1 // 2), I(h, 0, 0), dual(I(h, 0, 0)), dual(I(b, 1, -1 // 2)))] .= sgn * 1
     return t
 end
-function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                      slave_fermion::Bool=false)
     throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const d⁺d⁻ = d_plus_d_min
@@ -463,7 +499,8 @@ The only nonzero matrix element corresponds to `|0↑⟩ <-- |↑0⟩`.
 function u_min_u_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return u_min_u_plus(ComplexF64, P, S; slave_fermion)
 end
-function u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
     return copy(adjoint(u_plus_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
@@ -480,7 +517,8 @@ The only nonzero matrix element corresponds to `|0↓⟩ <-- |↓0⟩`.
 function d_min_d_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return d_min_d_plus(ComplexF64, P, S; slave_fermion)
 end
-function d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
     return copy(adjoint(d_plus_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
@@ -495,27 +533,32 @@ The only nonzero matrix element corresponds to `|00⟩ <-- |↑↓⟩`.
 function u_min_d_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return u_min_d_min(ComplexF64, P, S; slave_fermion)
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+                     slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(h), I(h), dual(I(b)), dual(I(b)))][1, 1, 1, 2] = -sgn * 1
     return t
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep};
+                     slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(h, 0), I(h, 0), dual(I(b, 1 // 2)), dual(I(b, -1 // 2)))] .= -sgn * 1
     return t
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector}; slave_fermion::Bool=false)
+function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector};
+                     slave_fermion::Bool=false)
     throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry"))
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
     throw(ArgumentError("`u_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
     throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` spin symmetry"))
 end
 const u⁻d⁻ = u_min_d_min
@@ -529,27 +572,32 @@ The only nonzero matrix element corresponds to `|00⟩ <-- |↓↑⟩`.
 function d_min_u_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return d_min_u_min(ComplexF64, P, S; slave_fermion)
 end
-function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+                     slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(h), I(h), dual(I(b)), dual(I(b)))][1, 1, 2, 1] = -sgn * 1
     return t
 end
-function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep};
+                     slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
     t[(I(h, 0), I(h, 0), dual(I(b, -1 // 2)), dual(I(b, 1 // 2)))] .= -sgn * 1
     return t
 end
-function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector}; slave_fermion::Bool=false)
+function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector};
+                     slave_fermion::Bool=false)
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry"))
 end
-function d_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
     throw(ArgumentError("`d_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
@@ -563,12 +611,14 @@ This is the sum of `u_plus_u_min` and `d_plus_d_min`.
 function e_plus_e_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return e_plus_e_min(ComplexF64, P, S; slave_fermion)
 end
-function e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
     return u_plus_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion) +
            d_plus_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
-function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, SU2Irrep; slave_fermion)
     I = sectortype(t)
     if slave_fermion
@@ -582,7 +632,8 @@ function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; sl
     end
     return t
 end
-function e_plus_e_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function e_plus_e_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, U1Irrep, SU2Irrep; slave_fermion)
     I = sectortype(t)
     if slave_fermion
@@ -608,7 +659,8 @@ This is the sum of `u_min_u_plus` and `d_min_d_plus`.
 function e_min_e_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return e_min_e_plus(ComplexF64, P, S; slave_fermion)
 end
-function e_min_e_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function e_min_e_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector};
                       slave_fermion::Bool=false)
     return -copy(adjoint(e_plus_e_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
@@ -622,8 +674,9 @@ Return the two-body singlet operator ``(e_{1,↓} e_{2,↑} - e_{1,↓} e_{2,↑
 function singlet_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return singlet_min(ComplexF64, P, S; slave_fermion)
 end
-function singlet_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
-                   slave_fermion::Bool=false)
+function singlet_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                     spin_symmetry::Type{<:Sector};
+                     slave_fermion::Bool=false)
     return (u_min_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion) -
             d_min_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)) / sqrt(2)
 end
@@ -638,8 +691,9 @@ Return the two-body operator that describes a particle that hops between the fir
 function e_hopping(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return e_hopping(ComplexF64, P, S; slave_fermion)
 end
-function e_hopping(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
-               slave_fermion::Bool=false)
+function e_hopping(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                   spin_symmetry::Type{<:Sector};
+                   slave_fermion::Bool=false)
     return e_plus_e_min(elt, particle_symmetry, spin_symmetry; slave_fermion) -
            e_min_e_plus(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
@@ -654,28 +708,32 @@ The only nonzero matrix element corresponds to `|↑↓⟩ <-- |↓↑⟩`.
 function S_plus_S_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_plus_S_min(ComplexF64, P, S; slave_fermion)
 end
-function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial}; slave_fermion::Bool=false)
+function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b), I(b), dual(I(b)), dual(I(b)))][1, 2, 2, 1] = 1
     return t
 end
-function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1 // 2), I(b, -1 // 2), dual(I(b, -1 // 2)), dual(I(b, 1 // 2)))] .= 1
     return t
 end
-function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial}; slave_fermion::Bool=false)
+function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, U1Irrep, Trivial; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
     t[(I(b, 1), I(b, 1), dual(I(b, 1)), dual(I(b, 1)))][1, 2, 2, 1] = 1
     return t
 end
-function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep}; slave_fermion::Bool=false)
+function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep};
+                      slave_fermion::Bool=false)
     t = two_site_operator(elt, U1Irrep, U1Irrep; slave_fermion)
     I = sectortype(t)
     b = slave_fermion ? 0 : 1
@@ -693,8 +751,9 @@ The only nonzero matrix element corresponds to `|↓↑⟩ <-- |↑↓⟩`.
 function S_min_S_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_min_S_plus(ComplexF64, P, S; slave_fermion)
 end
-function S_min_S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
-                   slave_fermion::Bool=false)
+function S_min_S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector};
+                      slave_fermion::Bool=false)
     return copy(adjoint(S_plus_S_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
 const S⁻S⁺ = S_min_S_plus
@@ -707,7 +766,8 @@ Return the spin exchange operator S⋅S.
 function S_exchange(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_exchange(ComplexF64, P, S; slave_fermion)
 end
-function S_exchange(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+function S_exchange(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                    spin_symmetry::Type{<:Sector};
                     slave_fermion::Bool=false)
     Sz = S_z(elt, particle_symmetry, spin_symmetry; slave_fermion)
     return (1 / 2) * (S_plus_S_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
@@ -715,7 +775,8 @@ function S_exchange(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin
                       S_min_S_plus(elt, particle_symmetry, spin_symmetry; slave_fermion)) +
            Sz ⊗ Sz
 end
-function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep};
+                    slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, SU2Irrep; slave_fermion)
 
     for (s, f) in fusiontrees(t)
@@ -726,7 +787,8 @@ function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}; slav
     end
     return t
 end
-function S_exchange(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep}; slave_fermion::Bool=false)
+function S_exchange(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                    slave_fermion::Bool=false)
     t = two_site_operator(elt, U1Irrep, SU2Irrep; slave_fermion)
 
     for (s, f) in fusiontrees(t)

--- a/test/bosonoperators.jl
+++ b/test/bosonoperators.jl
@@ -10,35 +10,39 @@ using StableRNGs
     cutoff = 4
 
     # inferrability
-    A = @inferred a(; cutoff)
-    A⁺ = @inferred a⁺(; cutoff)
+    B⁻ = @inferred b⁻(; cutoff)
+    B⁺ = @inferred b⁺(; cutoff)
     N = @inferred n(; cutoff)
-    AA = @inferred aa(; cutoff)
-    A⁺A = @inferred a⁺a(; cutoff)
-    AA⁺ = @inferred aa⁺(; cutoff)
-    A⁺A⁺ = @inferred a⁺a⁺(; cutoff)
+    B⁻B⁻ = @inferred b⁻b⁻(; cutoff)
+    B⁺B⁻ = @inferred b⁺b⁻(; cutoff)
+    B⁻B⁺ = @inferred b⁻b⁺(; cutoff)
+    B⁺B⁺ = @inferred b⁺b⁺(; cutoff)
+    Bhop = @inferred b_hop(; cutoff)
     V = @inferred boson_space(Trivial; cutoff)
 
     # test adjoints
-    @test A' ≈ A⁺
-    @test AA' ≈ A⁺A⁺
-    @test A⁺A' ≈ AA⁺
+    @test B⁻' ≈ B⁺
+    @test B⁻B⁻' ≈ B⁺B⁺
+    @test B⁺B⁻' ≈ B⁻B⁺
     @test N' ≈ N
 
     # commutation relations are modified because hilbert space has cutoff!
     # [a, a⁺] = 1 except when aplied to `|cutoff>`
     id_modified = id(V)
     id_modified[cutoff + 1, cutoff + 1] = -cutoff
-    @test (A * A⁺ - A⁺ * A) ≈ id_modified
+    @test (B⁻ * B⁺ - B⁺ * B⁻) ≈ id_modified
 
     # definition of N
-    @test A' * A ≈ N
+    @test B⁻' * B⁻ ≈ N
+
+    # definition of Bhop
+    @test Bhop ≈ B⁺B⁻ + B⁻B⁺
 
     # composite operators
-    @test AA ≈ A ⊗ A
-    @test A⁺A ≈ A⁺ ⊗ A
-    @test AA⁺ ≈ A ⊗ A⁺
-    @test A⁺A⁺ ≈ A⁺ ⊗ A⁺
+    @test B⁻B⁻ ≈ B⁻ ⊗ B⁻
+    @test B⁺B⁻ ≈ B⁺ ⊗ B⁻
+    @test B⁻B⁺ ≈ B⁻ ⊗ B⁺
+    @test B⁺B⁺ ≈ B⁺ ⊗ B⁺
 end
 
 @testset "U1-symmetric bosonic operators" begin
@@ -47,24 +51,24 @@ end
     rng = StableRNG(123)
     # inferrability
     N = @inferred n(U1Irrep; cutoff)
-    A⁺A = @inferred a⁺a(U1Irrep; cutoff)
-    AA⁺ = @inferred aa⁺(U1Irrep; cutoff)
+    B⁺B⁻ = @inferred b⁺b⁻(U1Irrep; cutoff)
+    B⁻B⁺ = @inferred b⁻b⁺(U1Irrep; cutoff)
     V = @inferred boson_space(U1Irrep; cutoff)
 
     # non-symmetric operators throw error
-    @test_throws ArgumentError a(U1Irrep; cutoff)
-    @test_throws ArgumentError a⁺(U1Irrep; cutoff)
+    @test_throws ArgumentError b⁻(U1Irrep; cutoff)
+    @test_throws ArgumentError b⁺(U1Irrep; cutoff)
 
-    @test_throws ArgumentError a_plusplus(U1Irrep; cutoff)
-    @test_throws ArgumentError a_minmin(U1Irrep; cutoff)
+    @test_throws ArgumentError b_plus_b_plus(U1Irrep; cutoff)
+    @test_throws ArgumentError b_min_b_min(U1Irrep; cutoff)
 
     L = 4
-    a_pm, a_mp, a_n = rand(rng, 3)
-    O_u1 = (N ⊗ id(V) + id(V) ⊗ N) * a_n + AA⁺ * a_mp + A⁺A * a_pm
+    b_pm, b_mp, b_n = rand(rng, 3)
+    O_u1 = (N ⊗ id(V) + id(V) ⊗ N) * b_n + B⁻B⁺ * b_mp + B⁺B⁻ * b_pm
 
     O_triv = (n(; cutoff) ⊗ id(boson_space(Trivial; cutoff)) +
-              id(boson_space(Trivial; cutoff)) ⊗ n(; cutoff)) * a_n +
-             a⁺a(; cutoff) * a_pm + aa⁺(; cutoff) * a_mp
+              id(boson_space(Trivial; cutoff)) ⊗ n(; cutoff)) * b_n +
+             b⁺b⁻(; cutoff) * b_pm + b⁻b⁺(; cutoff) * b_mp
 
     test_operator(O_u1, O_triv; L)
 end
@@ -76,15 +80,15 @@ end
         rng = StableRNG(123)
         # inferrability
         N = @inferred n(U1Irrep; cutoff)
-        A⁺A = @inferred a⁺a(U1Irrep; cutoff)
-        AA⁺ = @inferred aa⁺(U1Irrep; cutoff)
+        B⁺B⁻ = @inferred b⁺b⁻(U1Irrep; cutoff)
+        B⁻B⁺ = @inferred b⁻b⁺(U1Irrep; cutoff)
         V = @inferred boson_space(U1Irrep; cutoff)
 
-        a_pm, a_mp, a_n = rand(rng, 3)
-        O = (N ⊗ id(V) + id(V) ⊗ N) * a_n + AA⁺ * a_mp + A⁺A * a_pm
+        b_pm, b_mp, b_n = rand(rng, 3)
+        O = (N ⊗ id(V) + id(V) ⊗ N) * b_n + B⁻B⁺ * b_mp + B⁺B⁻ * b_pm
 
-        true_eigenvals = sort([0, 2 * a_n, a_n + sqrt(a_mp * a_pm),
-                               a_n - sqrt(a_mp * a_pm)])
+        true_eigenvals = sort([0, 2 * b_n, b_n + sqrt(b_mp * b_pm),
+                               b_n - sqrt(b_mp * b_pm)])
         eigenvals = expanded_eigenvalues(O; L)
         @test eigenvals ≈ true_eigenvals
     end

--- a/test/fermionoperators.jl
+++ b/test/fermionoperators.jl
@@ -7,24 +7,26 @@ using TensorKitTensors.FermionOperators
 using StableRNGs
 
 # anticommutation relations
-# {cᵢ†, cⱼ†} = 0 = {cᵢ, cⱼ}
-# {cᵢ, cⱼ†} = δᵢⱼ
+# {fᵢ†, fⱼ†} = 0 = {fᵢ, fⱼ}
+# {fᵢ, fⱼ†} = δᵢⱼ
 
 @testset "simple fermions" begin
-    @test c⁻c⁻() ≈ -permute(c⁻c⁻(), ((2, 1), (4, 3)))
-    @test c⁺c⁺() ≈ -permute(c⁺c⁺(), ((2, 1), (4, 3)))
+    @test f⁻f⁻() ≈ -permute(f⁻f⁻(), ((2, 1), (4, 3)))
+    @test f⁺f⁺() ≈ -permute(f⁺f⁺(), ((2, 1), (4, 3)))
 
     # the following doesn't hold
     # I don't think I can get all of these to hold simultaneously?
-    # @test cc⁺ ≈ -permute(c⁺c, (2, 1), (4, 3))
+    # @test ff⁺ ≈ -permute(f⁺f, (2, 1), (4, 3))
 
-    @test c⁻c⁺()' ≈ -c⁺c⁻()
-    @test c⁻c⁻()' ≈ c⁺c⁺()
-    @test (c⁺c⁻() - c⁻c⁺())' ≈ c⁺c⁻() - c⁻c⁺()
-    @test (c⁺c⁻() + c⁻c⁺())' ≈ -(c⁻c⁺() + c⁺c⁻())
+    @test f⁻f⁺()' ≈ -f⁺f⁻()
+    @test f⁻f⁻()' ≈ f⁺f⁺()
+    @test (f⁺f⁻() - f⁻f⁺())' ≈ f⁺f⁻() - f⁻f⁺()
+    @test (f⁺f⁻() + f⁻f⁺())' ≈ -(f⁻f⁺() + f⁺f⁻())
 
-    @plansor c_number[-1; -2] := c⁺c⁻()[-1 1; 3 2] * τ[3 2; -2 1]
-    @test c_number ≈ c_num()
+    @plansor f_number[-1; -2] := f⁺f⁻()[-1 1; 3 2] * τ[3 2; -2 1]
+    @test f_number ≈ f_num()
+
+    @test f_hop() ≈ f_plus_f_min() - f_min_f_plus()
 end
 
 @testset "Exact Diagonalization" begin
@@ -34,7 +36,7 @@ end
     t, V, mu = rand(rng, 3)
     pspace = fermion_space()
 
-    H = -t * (c⁺c⁻() - c⁻c⁺()) +
+    H = -t * (f⁺f⁻() - f⁻f⁺()) +
         V * ((n() - 0.5 * id(pspace)) ⊗ (n() - 0.5 * id(pspace))) -
         0.5 * mu * (n() ⊗ id(pspace) + id(pspace) ⊗ n())
 

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -12,7 +12,6 @@ implemented_symmetries = [(Trivial, Trivial), (Trivial, U1Irrep), (Trivial, SU2I
 @testset "Compare symmetric with trivial tensors" begin
     for particle_symmetry in [Trivial, U1Irrep, SU2Irrep],
         spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
-
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             space = hubbard_space(particle_symmetry, spin_symmetry)
 
@@ -38,7 +37,6 @@ end
 @testset "basic properties" begin
     for particle_symmetry in (Trivial, U1Irrep, SU2Irrep),
         spin_symmetry in (Trivial, U1Irrep, SU2Irrep)
-
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             # test hermiticity
             @test e_plus_e_min(particle_symmetry, spin_symmetry)' ≈
@@ -71,9 +69,9 @@ end
 
             # test hopping operator
             @test e_hop(particle_symmetry, spin_symmetry) ≈
-            e_plus_e_min(particle_symmetry, spin_symmetry) -
-            e_min_e_plus(particle_symmetry, spin_symmetry)
-            
+                  e_plus_e_min(particle_symmetry, spin_symmetry) -
+                  e_min_e_plus(particle_symmetry, spin_symmetry)
+
         else
             @test_broken e_plus_e_min(particle_symmetry, spin_symmetry)
             @test_broken e_min_e_plus(particle_symmetry, spin_symmetry)
@@ -129,7 +127,6 @@ end
 @testset "Exact diagonalisation" begin
     for particle_symmetry in [Trivial, U1Irrep, SU2Irrep],
         spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
-
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             rng = StableRNG(123)
 

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -16,20 +16,20 @@ implemented_symmetries = [(Trivial, Trivial), (Trivial, U1Irrep), (Trivial, SU2I
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             space = hubbard_space(particle_symmetry, spin_symmetry)
 
-            O = c_plus_c_min(ComplexF64, particle_symmetry, spin_symmetry)
-            O_triv = c_plus_c_min(ComplexF64, Trivial, Trivial)
+            O = e_plus_e_min(ComplexF64, particle_symmetry, spin_symmetry)
+            O_triv = e_plus_e_min(ComplexF64, Trivial, Trivial)
             test_operator(O, O_triv)
 
-            O = c_num(ComplexF64, particle_symmetry, spin_symmetry)
-            O_triv = c_num(ComplexF64, Trivial, Trivial)
+            O = e_num(ComplexF64, particle_symmetry, spin_symmetry)
+            O_triv = e_num(ComplexF64, Trivial, Trivial)
             test_operator(O, O_triv)
 
             O = ud_num(ComplexF64, particle_symmetry, spin_symmetry)
             O_triv = ud_num(ComplexF64, Trivial, Trivial)
             test_operator(O, O_triv)
         else
-            @test_broken c_plus_c_min(ComplexF64, particle_symmetry, spin_symmetry)
-            @test_broken c_num(ComplexF64, particle_symmetry, spin_symmetry)
+            @test_broken e_plus_e_min(ComplexF64, particle_symmetry, spin_symmetry)
+            @test_broken e_num(ComplexF64, particle_symmetry, spin_symmetry)
             @test_broken ud_num(ComplexF64, particle_symmetry, spin_symmetry)
         end
     end
@@ -41,8 +41,8 @@ end
 
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             # test hermiticity
-            @test c_plus_c_min(particle_symmetry, spin_symmetry)' ≈
-                  -c_min_c_plus(particle_symmetry, spin_symmetry)
+            @test e_plus_e_min(particle_symmetry, spin_symmetry)' ≈
+                  -e_min_e_plus(particle_symmetry, spin_symmetry)
             if spin_symmetry !== SU2Irrep
                 @test d_plus_d_min(particle_symmetry, spin_symmetry)' ≈
                       d_min_d_plus(particle_symmetry, spin_symmetry)
@@ -56,7 +56,7 @@ end
 
             # test number operator
             if spin_symmetry !== SU2Irrep
-                @test c_num(particle_symmetry, spin_symmetry) ≈
+                @test e_num(particle_symmetry, spin_symmetry) ≈
                       u_num(particle_symmetry, spin_symmetry) +
                       d_num(particle_symmetry, spin_symmetry)
                 @test ud_num(particle_symmetry, spin_symmetry) ≈
@@ -68,9 +68,15 @@ end
                 @test_throws ArgumentError u_plus_u_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_plus_d_min(particle_symmetry, spin_symmetry)
             end
+
+            # test hopping operator
+            @test e_hop(particle_symmetry, spin_symmetry) ≈
+            e_plus_e_min(particle_symmetry, spin_symmetry) -
+            e_min_e_plus(particle_symmetry, spin_symmetry)
+            
         else
-            @test_broken c_plus_c_min(particle_symmetry, spin_symmetry)
-            @test_broken c_min_c_plus(particle_symmetry, spin_symmetry)
+            @test_broken e_plus_e_min(particle_symmetry, spin_symmetry)
+            @test_broken e_min_e_plus(particle_symmetry, spin_symmetry)
             @test_broken d_plus_d_min(particle_symmetry, spin_symmetry)
             @test_broken u_plus_u_min(particle_symmetry, spin_symmetry)
         end
@@ -78,10 +84,10 @@ end
 end
 
 function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu, L)
-    hopping = -t * (c_plus_c_min(particle_symmetry, spin_symmetry) -
-                    c_min_c_plus(particle_symmetry, spin_symmetry))
+    hopping = -t * (e_plus_e_min(particle_symmetry, spin_symmetry) -
+                    e_min_e_plus(particle_symmetry, spin_symmetry))
     interaction = U * ud_num(particle_symmetry, spin_symmetry)
-    chemical_potential = mu * c_num(particle_symmetry, spin_symmetry)
+    chemical_potential = mu * e_num(particle_symmetry, spin_symmetry)
     I = id(hubbard_space(particle_symmetry, spin_symmetry))
     H = sum(1:(L - 1)) do i
             return reduce(⊗, insert!(collect(Any, fill(I, L - 2)), i, hopping))

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -12,6 +12,7 @@ implemented_symmetries = [(Trivial, Trivial), (Trivial, U1Irrep), (Trivial, SU2I
 @testset "Compare symmetric with trivial tensors" begin
     for particle_symmetry in [Trivial, U1Irrep, SU2Irrep],
         spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
+
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             space = hubbard_space(particle_symmetry, spin_symmetry)
 
@@ -37,6 +38,7 @@ end
 @testset "basic properties" begin
     for particle_symmetry in (Trivial, U1Irrep, SU2Irrep),
         spin_symmetry in (Trivial, U1Irrep, SU2Irrep)
+
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             # test hermiticity
             @test e_plus_e_min(particle_symmetry, spin_symmetry)' ≈
@@ -127,6 +129,7 @@ end
 @testset "Exact diagonalisation" begin
     for particle_symmetry in [Trivial, U1Irrep, SU2Irrep],
         spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
+
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             rng = StableRNG(123)
 

--- a/test/spinoperators.jl
+++ b/test/spinoperators.jl
@@ -19,11 +19,11 @@ end
     Z = @inferred S_z(; spin)
     S⁺ = @inferred S_plus(; spin)
     S⁻ = @inferred S_min(; spin)
-    S⁺⁻ = @inferred S_plusmin(; spin)
-    S⁻⁺ = @inferred S_minplus(; spin)
-    XX = @inferred S_xx(; spin)
-    YY = @inferred S_yy(; spin)
-    ZZ = @inferred S_zz(; spin)
+    S⁺S⁻ = @inferred S_plus_S_min(; spin)
+    S⁻S⁺ = @inferred S_min_S_plus(; spin)
+    XX = @inferred S_x_S_x(; spin)
+    YY = @inferred S_y_S_y(; spin)
+    ZZ = @inferred S_z_S_z(; spin)
     SS = @inferred S_exchange(; spin)
     Svec = [X Y Z]
 
@@ -50,9 +50,9 @@ end
     @test XX ≈ X ⊗ X
     @test YY ≈ Y ⊗ Y
     @test ZZ ≈ Z ⊗ Z
-    @test S⁺⁻ ≈ S⁺ ⊗ S⁻
-    @test S⁻⁺ ≈ S⁻ ⊗ S⁺
-    @test (S⁺⁻ + S⁻⁺) / 2 ≈ XX + YY
+    @test S⁺S⁻ ≈ S⁺ ⊗ S⁻
+    @test S⁻S⁺ ≈ S⁻ ⊗ S⁺
+    @test (S⁺S⁻ + S⁻S⁺) / 2 ≈ XX + YY
     @test SS ≈ X ⊗ X + Y ⊗ Y + Z ⊗ Z
     @test SS ≈ Z ⊗ Z + (S⁺ ⊗ S⁻ + S⁻ ⊗ S⁺) / 2
 end
@@ -62,19 +62,19 @@ end
 
     # inferrability
     X = @inferred S_x(Z2Irrep)
-    XX = @inferred S_xx(Z2Irrep)
-    ZZ = @inferred S_zz(Z2Irrep)
+    XX = @inferred S_x_S_x(Z2Irrep)
+    ZZ = @inferred S_z_S_z(Z2Irrep)
 
     @test_throws ArgumentError S_x(Z2Irrep; spin=1)
-    @test_throws ArgumentError S_xx(Z2Irrep; spin=1)
-    @test_throws ArgumentError S_zz(Z2Irrep; spin=1)
+    @test_throws ArgumentError S_x_S_x(Z2Irrep; spin=1)
+    @test_throws ArgumentError S_z_S_z(Z2Irrep; spin=1)
 
     @test_throws ArgumentError S_plus(Z2Irrep)
     @test_throws ArgumentError S_min(Z2Irrep)
-    @test_throws ArgumentError S_plusmin(Z2Irrep)
-    @test_throws ArgumentError S_minplus(Z2Irrep)
+    @test_throws ArgumentError S_plus_S_min(Z2Irrep)
+    @test_throws ArgumentError S_min_S_plus(Z2Irrep)
     @test_throws ArgumentError S_y(Z2Irrep)
-    @test_throws ArgumentError S_yy(Z2Irrep)
+    @test_throws ArgumentError S_y_S_y(Z2Irrep)
     @test_throws ArgumentError S_z(Z2Irrep)
 
     @test_broken S_exchange(Z2Irrep)
@@ -84,7 +84,7 @@ end
     O_z2 = (X ⊗ id(domain(X)) + id(domain(X)) ⊗ X) * a_x + XX * a_xx + ZZ * a_zz
 
     O_triv = (S_x() ⊗ id(domain(S_x())) + id(domain(S_x())) ⊗ S_x()) * a_x +
-             S_xx() * a_xx + S_zz() * a_zz
+             S_x_S_x() * a_xx + S_z_S_z() * a_zz
 
     test_operator(O_z2, O_triv; L)
 end
@@ -94,20 +94,20 @@ end
 
     # inferrability
     Z = @inferred S_z(U1Irrep; spin)
-    ZZ = @inferred S_zz(U1Irrep; spin)
-    plusmin = @inferred S_plusmin(U1Irrep; spin)
-    minplus = @inferred S_minplus(U1Irrep; spin)
+    ZZ = @inferred S_z_S_z(U1Irrep; spin)
+    plusmin = @inferred S_plus_S_min(U1Irrep; spin)
+    minplus = @inferred S_min_S_plus(U1Irrep; spin)
     exchange = @inferred S_exchange(U1Irrep; spin)
 
     @test_throws ArgumentError S_x(U1Irrep; spin)
     @test_throws ArgumentError S_y(U1Irrep; spin)
     @test_throws ArgumentError S_plus(U1Irrep; spin)
     @test_throws ArgumentError S_min(U1Irrep; spin)
-    @test_throws ArgumentError S_xx(U1Irrep; spin)
-    @test_throws ArgumentError S_yy(U1Irrep; spin)
+    @test_throws ArgumentError S_x_S_x(U1Irrep; spin)
+    @test_throws ArgumentError S_y_S_y(U1Irrep; spin)
 
     L = 4
-    for f in (S_z, S_zz, S_plusmin, S_minplus, S_exchange)
+    for f in (S_z, S_z_S_z, S_plus_S_min, S_min_S_plus, S_exchange)
         test_operator(f(U1Irrep; spin), f(; spin); L)
     end
 
@@ -119,9 +119,9 @@ end
            exchange * a_exchange
     O_triv = (S_z(; spin) ⊗ id(domain(S_z(; spin))) +
               id(domain(S_z(; spin))) ⊗ S_z(; spin)) * a_z +
-             S_zz(; spin) * a_zz +
-             S_plusmin(; spin) * a_plusmin +
-             S_minplus(; spin) * a_minplus +
+             S_z_S_z(; spin) * a_zz +
+             S_plus_S_min(; spin) * a_plusmin +
+             S_min_S_plus(; spin) * a_minplus +
              S_exchange(; spin) * a_exchange
     test_operator(O_u1, O_triv; L)
 end
@@ -129,9 +129,9 @@ end
 @testset "Exact diagonalisation for $sector symmetry" for sector in [Trivial U1Irrep]
     spin = 1
 
-    ZZ = @inferred S_zz(sector; spin)
-    plusmin = @inferred S_plusmin(sector; spin)
-    minplus = @inferred S_minplus(sector; spin)
+    ZZ = @inferred S_z_S_z(sector; spin)
+    plusmin = @inferred S_plus_S_min(sector; spin)
+    minplus = @inferred S_min_S_plus(sector; spin)
     O = ZZ + 0.5 * (plusmin + minplus)
 
     true_eigenvals = vcat([-2.0], repeat([-1.0], 3), repeat([1.0], 5))

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -12,7 +12,6 @@ implemented_symmetries = [(Trivial, Trivial), (Trivial, U1Irrep), (Trivial, SU2I
 @testset "Compare symmetric with trivial tensors" begin
     for particle_symmetry in [Trivial, U1Irrep],
         spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
-
         for slave_fermion in (false, true)
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 space = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
@@ -38,7 +37,6 @@ end
     for slave_fermion in (false, true)
         for particle_symmetry in [Trivial, U1Irrep],
             spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
-
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 # test hermiticity
                 @test e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
@@ -95,7 +93,7 @@ end
                           sqrt(2)
                 else
                     @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry;
-                                                         slave_fermion)
+                                                           slave_fermion)
                     @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
                     @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry;
@@ -180,7 +178,6 @@ end
 
         for particle_symmetry in (Trivial, U1Irrep),
             spin_symmetry in (Trivial, U1Irrep, SU2Irrep)
-
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 if (particle_symmetry, spin_symmetry) == (Trivial, Trivial)
                     continue
@@ -206,7 +203,6 @@ end
 
     for particle_symmetry in [Trivial, U1Irrep],
         spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
-
         for slave_fermion in (false, true)
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 t, J = rand(rng, 2)

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -17,18 +17,18 @@ implemented_symmetries = [(Trivial, Trivial), (Trivial, U1Irrep), (Trivial, SU2I
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 space = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
 
-                O = c_plus_c_min(ComplexF64, particle_symmetry, spin_symmetry;
+                O = e_plus_e_min(ComplexF64, particle_symmetry, spin_symmetry;
                                  slave_fermion)
-                O_triv = c_plus_c_min(ComplexF64, Trivial, Trivial; slave_fermion)
+                O_triv = e_plus_e_min(ComplexF64, Trivial, Trivial; slave_fermion)
                 test_operator(O, O_triv)
 
-                O = c_num(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
-                O_triv = c_num(ComplexF64, Trivial, Trivial; slave_fermion)
+                O = e_num(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
+                O_triv = e_num(ComplexF64, Trivial, Trivial; slave_fermion)
                 test_operator(O, O_triv)
 
             else
-                @test_broken c_plus_c_min(ComplexF64, particle_symmetry, spin_symmetry)
-                @test_broken c_num(ComplexF64, particle_symmetry, spin_symmetry)
+                @test_broken e_plus_e_min(ComplexF64, particle_symmetry, spin_symmetry)
+                @test_broken e_num(ComplexF64, particle_symmetry, spin_symmetry)
             end
         end
     end
@@ -41,8 +41,8 @@ end
 
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 # test hermiticity
-                @test c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
-                      -c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)
+                @test e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
+                      -e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)
                 if spin_symmetry !== SU2Irrep
                     @test d_plus_d_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
                           d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
@@ -69,7 +69,7 @@ end
 
                 # test number operator
                 if spin_symmetry !== SU2Irrep
-                    @test c_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                    @test e_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
                           u_num(particle_symmetry, spin_symmetry; slave_fermion) +
                           d_num(particle_symmetry, spin_symmetry; slave_fermion)
                     @test u_num(particle_symmetry, spin_symmetry; slave_fermion) *
@@ -78,8 +78,8 @@ end
                           u_num(particle_symmetry, spin_symmetry; slave_fermion)
                     @test TensorKit.id(tj_space(particle_symmetry, spin_symmetry;
                                                 slave_fermion)) ≈
-                          c_num_hole(particle_symmetry, spin_symmetry; slave_fermion) +
-                          c_num(particle_symmetry, spin_symmetry; slave_fermion)
+                          h_num(particle_symmetry, spin_symmetry; slave_fermion) +
+                          e_num(particle_symmetry, spin_symmetry; slave_fermion)
                 else
                     @test_throws ArgumentError u_num(particle_symmetry, spin_symmetry;
                                                      slave_fermion)
@@ -89,18 +89,23 @@ end
 
                 # test spin operator
                 if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
-                    @test c_singlet(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                    @test singlet_min(particle_symmetry, spin_symmetry; slave_fermion) ≈
                           (u_min_d_min(particle_symmetry, spin_symmetry; slave_fermion) -
                            d_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)) /
                           sqrt(2)
                 else
-                    @test_throws ArgumentError c_singlet(particle_symmetry, spin_symmetry;
+                    @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry;
                                                          slave_fermion)
                     @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
                     @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
                 end
+
+                # test hopping operator
+                @test e_hopping(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                      e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion) -
+                      e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)
 
                 if spin_symmetry == Trivial
                     ε = zeros(ComplexF64, 3, 3, 3)
@@ -119,9 +124,12 @@ end
                     S = 1 / 2
                     @test sum(tr(Svec[i]^2) for i in 1:3) / (2S + 1) ≈ S * (S + 1)
                     # test S_plus and S_min
-                    @test S_plusmin(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                    @test S_plus_S_min(particle_symmetry, spin_symmetry; slave_fermion) ≈
                           S_plus(particle_symmetry, spin_symmetry; slave_fermion) ⊗
                           S_min(particle_symmetry, spin_symmetry; slave_fermion)
+                    @test S_min_S_plus(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                          S_min(particle_symmetry, spin_symmetry; slave_fermion) ⊗
+                          S_plus(particle_symmetry, spin_symmetry; slave_fermion)
                     # commutation relations
                     for i in 1:3, j in 1:3
                         @test Svec[i] * Svec[j] - Svec[j] * Svec[i] ≈
@@ -133,7 +141,7 @@ end
                 @test_broken d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
                 @test_broken u_plus_u_min(particle_symmetry, spin_symmetry; slave_fermion)
                 @test_broken u_min_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                @test_broken c_num(particle_symmetry, spin_symmetry; slave_fermion)
+                @test_broken e_num(particle_symmetry, spin_symmetry; slave_fermion)
                 @test_broken u_num(particle_symmetry, spin_symmetry; slave_fermion)
                 @test_broken d_num(particle_symmetry, spin_symmetry; slave_fermion)
             end
@@ -142,9 +150,9 @@ end
 end
 
 function tjhamiltonian(particle_symmetry, spin_symmetry; t, J, mu, L, slave_fermion)
-    num = c_num(particle_symmetry, spin_symmetry; slave_fermion)
-    hop_heis = (-t) * (c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) -
-                       c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)) +
+    num = e_num(particle_symmetry, spin_symmetry; slave_fermion)
+    hop_heis = (-t) * (e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion) -
+                       e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)) +
                J *
                (S_exchange(particle_symmetry, spin_symmetry; slave_fermion) -
                 (1 / 4) * (num ⊗ num))
@@ -202,10 +210,10 @@ end
         for slave_fermion in (false, true)
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 t, J = rand(rng, 2)
-                num = c_num(particle_symmetry, spin_symmetry; slave_fermion)
+                num = e_num(particle_symmetry, spin_symmetry; slave_fermion)
                 H = (-t) *
-                    (c_plus_c_min(particle_symmetry, spin_symmetry; slave_fermion) -
-                     c_min_c_plus(particle_symmetry, spin_symmetry; slave_fermion)) +
+                    (e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion) -
+                     e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)) +
                     J *
                     (S_exchange(particle_symmetry, spin_symmetry; slave_fermion) -
                      (1 / 4) * (num ⊗ num))

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -12,6 +12,7 @@ implemented_symmetries = [(Trivial, Trivial), (Trivial, U1Irrep), (Trivial, SU2I
 @testset "Compare symmetric with trivial tensors" begin
     for particle_symmetry in [Trivial, U1Irrep],
         spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
+
         for slave_fermion in (false, true)
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 space = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
@@ -37,6 +38,7 @@ end
     for slave_fermion in (false, true)
         for particle_symmetry in [Trivial, U1Irrep],
             spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
+
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 # test hermiticity
                 @test e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
@@ -178,6 +180,7 @@ end
 
         for particle_symmetry in (Trivial, U1Irrep),
             spin_symmetry in (Trivial, U1Irrep, SU2Irrep)
+
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 if (particle_symmetry, spin_symmetry) == (Trivial, Trivial)
                     continue
@@ -203,6 +206,7 @@ end
 
     for particle_symmetry in [Trivial, U1Irrep],
         spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
+
         for slave_fermion in (false, true)
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
                 t, J = rand(rng, 2)

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -45,13 +45,9 @@ end
                       -e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)
                 if spin_symmetry !== SU2Irrep
                     @test d_plus_d_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
-                          d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
+                          -d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
                     @test u_plus_u_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
-                          u_min_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                    @test d_plus_d_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
-                          d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                    @test u_plus_u_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
-                          u_min_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
+                          -u_min_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
                 else
                     @test_throws ArgumentError d_plus_d_min(particle_symmetry,
                                                             spin_symmetry;


### PR DESCRIPTION
This changes the conventions of the operators, after a discussion on the desired names with @lkdvos and @Jutho. 

The new conventions are

- `b` for bosons
- `f` for spinless fermions
- `e` for spinfull fermions (from 'electron') 
- `S` for spin operators

Additionally, the hopping operator `[flavor]_hopping` is added.