### PR TITLE
Reduce unnecessary manual definitions in TJOperators

### DIFF
--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -460,9 +460,7 @@ const d⁺d⁻ = d_plus_d_min
     u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
     u⁻u⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
-Return the Hermitian conjugate of `u_plus_u_min`, i.e.
-``(e†_{1,↑}, e_{2,↑})† = -e_{1,↑}, e†_{2,↑}`` (note the extra minus sign). 
-It annihilates a spin-up electron at the first site and creates a spin-up electron at the second.
+Return the two-body operator ``e_{1,↑}, e†_{2,↑}`` that annihilates a spin-up electron at the first site and creates a spin-up electron at the second.
 The only nonzero matrix element corresponds to `|0↑⟩ <-- |↑0⟩`.
 """ u_min_u_plus
 function u_min_u_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
@@ -479,9 +477,7 @@ const u⁻u⁺ = u_min_u_plus
     d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
     d⁻d⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
-Return the Hermitian conjugate of `d_plus_d_min`, i.e.
-``(e†_{1,↓}, e_{2,↓})† = -e_{1,↓}, e†_{2,↓}`` (note the extra minus sign). 
-It annihilates a spin-down electron at the first site and creates a spin-down electron at the second.
+Return the two-body operator ``e_{1,↓}, e†_{2,↓}`` that annihilates a spin-down electron at the first site and creates a spin-down electron at the second.
 The only nonzero matrix element corresponds to `|0↓⟩ <-- |↓0⟩`.
 """ d_min_d_plus
 function d_min_d_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -242,7 +242,7 @@ const nʰ = h_num
     S_x(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
     Sˣ(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
-Return the one-body spin-1/2 x-operator on the electrons.
+Return the one-body spin-1/2 x-operator on the electrons (only defined for `Trivial` spin symmetry).
 """ S_x
 function S_x(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial;
              slave_fermion::Bool=false)
@@ -272,7 +272,7 @@ const Sˣ = S_x
     S_y(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
     Sʸ(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
 
-Return the one-body spin-1/2 x-operator on the electrons (only defined for `Trivial` symmetry). 
+Return the one-body spin-1/2 y-operator on the electrons (only defined for `Trivial` spin symmetry). 
 """ S_y
 function S_y(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial;
              slave_fermion::Bool=false)

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -528,10 +528,6 @@ function u_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
                      slave_fermion::Bool=false)
     throw(ArgumentError("`u_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
-                     slave_fermion::Bool=false)
-    throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` spin symmetry"))
-end
 const u⁻d⁻ = u_min_d_min
 
 @doc """
@@ -567,10 +563,6 @@ end
 function d_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
                      slave_fermion::Bool=false)
     throw(ArgumentError("`d_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
-end
-function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
-                     slave_fermion::Bool=false)
-    throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
 

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -83,7 +83,7 @@ end
                                                      slave_fermion)
                 end
 
-                # test spin operator
+                # test singlet operator
                 if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
                     @test singlet_min(particle_symmetry, spin_symmetry; slave_fermion) ≈
                           (u_min_d_min(particle_symmetry, spin_symmetry; slave_fermion) -
@@ -103,6 +103,7 @@ end
                       e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion) -
                       e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)
 
+                # test spin operator
                 if spin_symmetry == Trivial
                     ε = zeros(ComplexF64, 3, 3, 3)
                     for i in 1:3


### PR DESCRIPTION
This PR removes some unnecessary manual definitions (by specifying matrix elements) for (mainly) the spin operators in TJOperators. 

- $S^+$ is the fundamental operator, from which we construct $S^- = (S^+)^\dagger, S^x = (S^+ + S^-) / 2, S^y = (S^+ - S^-) / (2i)$.
- The $S^z$ operator is now directly given by `(u_num - d_num) / 2`. 
- Some redundant (in my opinion) ArgumentErrors are removed. 
- The docstring of `u_min_u_plus` etc is updated (#17). I'll update the Hubbard model in a separate PR that will introduce spin and singlet operators. 