### PR TITLE
Add spin and singlet operators to HubbardOperators

### DIFF
--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -3,18 +3,18 @@ module HubbardOperators
 using TensorKit
 
 export hubbard_space
-export S_x, S_y, S_z, S_plus, S_min
-export e_plus_e_min, u_plus_u_min, d_plus_d_min
-export e_min_e_plus, u_min_u_plus, d_min_d_plus
-export u_min_d_min, d_min_u_min
 export e_num, u_num, d_num, ud_num
-export e_hopping, singlet_min
+export S_x, S_y, S_z, S_plus, S_min
+export u_plus_u_min, d_plus_d_min
+export u_min_u_plus, d_min_d_plus
+export u_min_d_min, d_min_u_min
+export e_plus_e_min, e_min_e_plus, singlet_min, e_hopping
 export S_plus_S_min, S_min_S_plus, S_exchange
 
+export nꜛ, nꜜ, nʰ, n
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
-export e⁺e⁻, u⁺u⁻, d⁺d⁻, e⁻e⁺, u⁻u⁺, d⁻d⁺
-export n, nꜛ, nꜜ, nꜛꜜ
-export e_hop, singlet⁻
+export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺, u⁻d⁻, d⁻u⁻
+export e⁺e⁻, e⁻e⁺, singlet⁻, e_hop
 export S⁻S⁺, S⁺S⁻
 
 """
@@ -242,6 +242,12 @@ function S_plus(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
     I = sectortype(t)
     t[(I(1, 1), dual(I(1, 1)))][1, 2] = 1.0
     return t
+end
+function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
+    throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `U1Ireep` spin symmetry"))
+end
+function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+    throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `SU2Irrep` spin symmetry"))
 end
 const S⁺ = S_plus
 

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -448,14 +448,12 @@ const d⁺d⁻ = d_plus_d_min
     u_min_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     u⁻u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
-Return the Hermitian conjugate of `u_plus_u_min`, i.e.
-``(e†_{1,↑}, e_{2,↑})† = -e_{1,↑}, e†_{2,↑}`` (note the extra minus sign). 
-It annihilates a spin-up particle at the first site and creates a spin-up particle at the second.
+Return the two-body operator ``e_{1,↑}, e†_{2,↑}`` that annihilates a spin-up particle at the first site and creates a spin-up particle at the second.
 """ u_min_u_plus
 u_min_u_plus(P::Type{<:Sector}, S::Type{<:Sector}) = u_min_u_plus(ComplexF64, P, S)
 function u_min_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
                       spin_symmetry::Type{<:Sector})
-    return copy(adjoint(u_plus_u_min(elt, particle_symmetry, spin_symmetry)))
+    return -copy(adjoint(u_plus_u_min(elt, particle_symmetry, spin_symmetry)))
 end
 const u⁻u⁺ = u_min_u_plus
 
@@ -463,14 +461,12 @@ const u⁻u⁺ = u_min_u_plus
     d_min_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     d⁻d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
-Return the Hermitian conjugate of `d_plus_d_min`, i.e.
-``(e†_{1,↓}, e_{2,↓})† = -e_{1,↓}, e†_{2,↓}`` (note the extra minus sign). 
-It annihilates a spin-down particle at the first site and creates a spin-down particle at the second.
+Return the two-body operator ``e_{1,↓}, e†_{2,↓}`` that annihilates a spin-down particle at the first site and creates a spin-down particle at the second.
 """ d_min_d_plus
 d_min_d_plus(P::Type{<:Sector}, S::Type{<:Sector}) = d_min_d_plus(ComplexF64, P, S)
 function d_min_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
                       spin_symmetry::Type{<:Sector})
-    return copy(adjoint(d_plus_d_min(elt, particle_symmetry, spin_symmetry)))
+    return -copy(adjoint(d_plus_d_min(elt, particle_symmetry, spin_symmetry)))
 end
 const d⁻d⁺ = d_min_d_plus
 

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -22,7 +22,7 @@ export S⁻S⁺, S⁺S⁻
 
 Return the local hilbert space for a Hubbard-type model with the given particle and spin symmetries. The four basis states are
 ```
-    |0⟩ (vacuum), |↑⟩ = (c↑)†|0⟩, |↓⟩ = (c↓)†|0⟩, |2⟩ = (c↑)†(c↓)†|0⟩.
+    |0⟩ (vacuum), |↑⟩ = (c↑)†|0⟩, |↓⟩ = (c↓)†|0⟩, |↑↓⟩ = (c↑)†(c↓)†|0⟩.
 ```
 The possible symmetries are `Trivial`, `U1Irrep`, and `SU2Irrep`, for both particle number and spin.
 """
@@ -554,8 +554,8 @@ const e_hop = e_hopping
 Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up particle at the first site and a spin-down particle at the second site.
 The nonzero matrix elements are
 ```
-    -|0,0⟩ ↤ |↑,↓⟩,     +|0,↑⟩ ↤ |↑,2⟩,
-    +|↓,0⟩ ↤ |2,↓⟩,     -|↓,↑⟩ ↤ |2,2⟩
+    -|0,0⟩ ↤ |↑,↓⟩,     +|0,↑⟩ ↤ |↑,↑↓⟩,
+    +|↓,0⟩ ↤ |↑↓,↓⟩,    -|↓,↑⟩ ↤ |↑↓,↑↓⟩
 ```
 """ u_min_d_min
 function u_min_d_min(P::Type{<:Sector}, S::Type{<:Sector})
@@ -597,8 +597,8 @@ const u⁻d⁻ = u_min_d_min
 Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down particle at the first site and a spin-up particle at the second site.
 The nonzero matrix elements are
 ```
-    -|0,0⟩ ↤ |↓,↑⟩,     -|0,↓⟩ ↤ |↓,2⟩
-    -|↑,0⟩ ↤ |2,↑⟩,     -|↑,↓⟩ ↤ |2,2⟩
+    -|0,0⟩ ↤ |↓,↑⟩,     -|0,↓⟩ ↤ |↓,↑↓⟩
+    -|↑,0⟩ ↤ |↑↓,↑⟩,    -|↑,↓⟩ ↤ |↑↓,↑↓⟩
 ```
 """ d_min_u_min
 function d_min_u_min(P::Type{<:Sector}, S::Type{<:Sector})

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -3,19 +3,27 @@ module HubbardOperators
 using TensorKit
 
 export hubbard_space
+export S_x, S_y, S_z, S_plus, S_min
 export e_plus_e_min, u_plus_u_min, d_plus_d_min
 export e_min_e_plus, u_min_u_plus, d_min_d_plus
+export u_min_d_min, d_min_u_min
 export e_num, u_num, d_num, ud_num
-export e_hopping
+export e_hopping, singlet_min
+export S_plus_S_min, S_min_S_plus, S_exchange
 
+export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
 export e⁺e⁻, u⁺u⁻, d⁺d⁻, e⁻e⁺, u⁻u⁺, d⁻d⁺
 export n, nꜛ, nꜜ, nꜛꜜ
-export e_hop
+export e_hop, singlet⁻
+export S⁻S⁺, S⁺S⁻
 
 """
     hubbard_space(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 
-Return the local hilbert space for a Hubbard-type model with the given particle and spin symmetries.
+Return the local hilbert space for a Hubbard-type model with the given particle and spin symmetries. The four basis states are
+```
+    |0⟩ (vacuum), |↑⟩ = (c↑)†|0⟩, |↓⟩ = (c↓)†|0⟩, |2⟩ = (c↑)†(c↓)†|0⟩.
+```
 The possible symmetries are `Trivial`, `U1Irrep`, and `SU2Irrep`, for both particle number and spin.
 """
 function hubbard_space((::Type{Trivial})=Trivial, (::Type{Trivial})=Trivial)
@@ -213,6 +221,94 @@ function ud_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     return t
 end
 const nꜛꜜ = ud_num
+
+@doc """
+    S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    S⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the spin-plus operator `S⁺ = e†_↑ e_↓` (only defined for `Trivial` spin symmetry).
+""" S_plus
+function S_plus(P::Type{<:Sector}, S::Type{<:Sector})
+    return S_plus(ComplexF64, P, S)
+end
+function S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    t = single_site_operator(elt, Trivial, Trivial)
+    I = sectortype(t)
+    t[(I(1), dual(I(1)))][1, 2] = 1.0
+    return t
+end
+function S_plus(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
+    t = single_site_operator(elt, U1Irrep, Trivial)
+    I = sectortype(t)
+    t[(I(1, 1), dual(I(1, 1)))][1, 2] = 1.0
+    return t
+end
+const S⁺ = S_plus
+
+@doc """
+    S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    S⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the spin-minus operator (only defined for `Trivial` spin symmetry).
+""" S_min
+function S_min(P::Type{<:Sector}, S::Type{<:Sector})
+    return S_min(ComplexF64, P, S)
+end
+function S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+               spin_symmetry::Type{<:Sector})
+    return copy(adjoint(S_plus(elt, particle_symmetry, spin_symmetry)))
+end
+const S⁻ = S_min
+
+@doc """
+    S_x(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    Sˣ(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the one-body spin-1/2 x-operator on the electrons (only defined for `Trivial` symmetry). .
+""" S_x
+function S_x(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial)
+    return S_x(ComplexF64, P, S)
+end
+function S_x(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+             spin_symmetry::Type{<:Sector})
+    return (S_plus(elt, particle_symmetry, spin_symmetry)
+            +
+            S_min(elt, particle_symmetry, spin_symmetry)) / 2
+end
+const Sˣ = S_x
+
+@doc """
+    S_y(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    Sʸ(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the one-body spin-1/2 y-operator on the electrons (only defined for `Trivial` symmetry). 
+""" S_y
+function S_y(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial)
+    return S_y(ComplexF64, P, S)
+end
+function S_y(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+             spin_symmetry::Type{<:Sector})
+    return (S_plus(elt, particle_symmetry, spin_symmetry)
+            -
+            S_min(elt, particle_symmetry, spin_symmetry)) / (2im)
+end
+const Sʸ = S_y
+
+@doc """
+    S_z(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    Sᶻ(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the one-body spin-1/2 z-operator on the electrons. 
+""" S_z
+function S_z(P::Type{<:Sector}=Trivial, S::Type{<:Sector}=Trivial)
+    return S_z(ComplexF64, P, S)
+end
+function S_z(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+             spin_symmetry::Type{<:Sector})
+    return (u_num(elt, particle_symmetry, spin_symmetry) -
+            d_num(elt, particle_symmetry, spin_symmetry)) / 2
+end
+const Sᶻ = S_z
 
 # Two site operators
 # ------------------
@@ -448,5 +544,196 @@ function e_hopping(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
            e_min_e_plus(elt, particle_symmetry, spin_symmetry)
 end
 const e_hop = e_hopping
+
+@doc """
+    u_min_d_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    u⁻d⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up particle at the first site and a spin-down particle at the second site.
+The nonzero matrix elements are
+```
+    -|0,0⟩ ↤ |↑,↓⟩,     +|0,↑⟩ ↤ |↑,2⟩,
+    +|↓,0⟩ ↤ |2,↓⟩,     -|↓,↑⟩ ↤ |2,2⟩
+```
+""" u_min_d_min
+function u_min_d_min(P::Type{<:Sector}, S::Type{<:Sector})
+    return u_min_d_min(ComplexF64, P, S)
+end
+function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    t = two_site_operator(elt, Trivial, Trivial)
+    I = sectortype(t)
+    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 2] = -1
+    t[(I(0), I(1), dual(I(1)), dual(I(0)))][1, 1, 1, 2] = 1
+    t[(I(1), I(0), dual(I(0)), dual(I(1)))][2, 1, 2, 2] = 1
+    t[(I(1), I(1), dual(I(0)), dual(I(0)))][2, 1, 2, 2] = -1
+    return t
+end
+function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
+    t = two_site_operator(elt, Trivial, U1Irrep)
+    I = sectortype(t)
+    t[(I(0, 0), I(0, 0), dual(I(1, 1 // 2)), dual(I(1, -1 // 2)))][1, 1, 1, 1] = -1
+    t[(I(0, 0), I(1, 1 // 2), dual(I(1, 1 // 2)), dual(I(0, 0)))][1, 1, 1, 2] = 1
+    t[(I(1, -1 // 2), I(0, 0), dual(I(0, 0)), dual(I(1, -1 // 2)))][1, 1, 2, 1] = 1
+    t[(I(1, -1 // 2), I(1, 1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 2, 2] = -1
+    return t
+end
+function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
+    throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry"))
+end
+function u_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+    throw(ArgumentError("`u_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
+end
+function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` spin symmetry"))
+end
+const u⁻d⁻ = u_min_d_min
+
+@doc """
+    d_min_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    d⁻u⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down particle at the first site and a spin-up particle at the second site.
+The nonzero matrix elements are
+```
+    -|0,0⟩ ↤ |↓,↑⟩,     -|0,↓⟩ ↤ |↓,2⟩
+    -|↑,0⟩ ↤ |2,↑⟩,     -|↑,↓⟩ ↤ |2,2⟩
+```
+""" d_min_u_min
+function d_min_u_min(P::Type{<:Sector}, S::Type{<:Sector})
+    return d_min_u_min(ComplexF64, P, S)
+end
+function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    t = two_site_operator(elt, Trivial, Trivial)
+    I = sectortype(t)
+    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 1] = -1
+    t[(I(0), I(1), dual(I(1)), dual(I(0)))][1, 2, 2, 2] = -1
+    t[(I(1), I(0), dual(I(0)), dual(I(1)))][1, 1, 2, 1] = -1
+    t[(I(1), I(1), dual(I(0)), dual(I(0)))][1, 2, 2, 2] = -1
+    return t
+end
+function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
+    t = two_site_operator(elt, Trivial, U1Irrep)
+    I = sectortype(t)
+    t[(I(0, 0), I(0, 0), dual(I(1, -1 // 2)), dual(I(1, 1 // 2)))][1, 1, 1, 1] = -1
+    t[(I(0, 0), I(1, -1 // 2), dual(I(1, -1 // 2)), dual(I(0, 0)))][1, 1, 1, 2] = -1
+    t[(I(1, 1 // 2), I(0, 0), dual(I(0, 0)), dual(I(1, 1 // 2)))][1, 1, 2, 1] = -1
+    t[(I(1, 1 // 2), I(1, -1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 2, 2] = -1
+    return t
+end
+function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
+    throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry"))
+end
+function d_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+    throw(ArgumentError("`d_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
+end
+function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
+end
+const d⁻u⁻ = d_min_u_min
+
+@doc """
+    singlet_min(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    singlet⁻(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body singlet operator ``(e_{1,↓} e_{2,↑} - e_{1,↓} e_{2,↑}) / sqrt(2)``.
+""" singlet_min
+function singlet_min(P::Type{<:Sector}, S::Type{<:Sector})
+    return singlet_min(ComplexF64, P, S)
+end
+function singlet_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                     spin_symmetry::Type{<:Sector})
+    return (u_min_d_min(elt, particle_symmetry, spin_symmetry) -
+            d_min_u_min(elt, particle_symmetry, spin_symmetry)) / sqrt(2)
+end
+const singlet⁻ = singlet_min
+
+@doc """
+    S_plus_S_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    S⁺S⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator S⁺S⁻.
+The only nonzero matrix element corresponds to `|↑,↓⟩ <-- |↓,↑⟩`.
+""" S_plus_S_min
+function S_plus_S_min(P::Type{<:Sector}, S::Type{<:Sector})
+    return S_plus_S_min(ComplexF64, P, S)
+end
+function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    t = two_site_operator(elt, Trivial, Trivial)
+    I = sectortype(t)
+    t[(I(1), I(1), dual(I(1)), dual(I(1)))][1, 2, 2, 1] = 1
+    return t
+end
+function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
+    t = two_site_operator(elt, Trivial, U1Irrep)
+    I = sectortype(t)
+    t[(I(1, 1 // 2), I(1, -1 // 2), dual(I(1, -1 // 2)), dual(I(1, 1 // 2)))] .= 1
+    return t
+end
+function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
+    t = two_site_operator(elt, U1Irrep, Trivial)
+    I = sectortype(t)
+    t[(I(1, 1), I(1, 1), dual(I(1, 1)), dual(I(1, 1)))][1, 2, 2, 1] = 1
+    return t
+end
+function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
+    t = two_site_operator(elt, U1Irrep, U1Irrep)
+    I = sectortype(t)
+    t[(I(1, 1, 1 // 2), I(1, 1, -1 // 2), dual(I(1, 1, -1 // 2)), dual(I(1, 1, 1 // 2)))] .= 1
+    return t
+end
+const S⁺S⁻ = S_plus_S_min
+
+@doc """
+    S_min_S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    S⁻S⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator S⁻S⁺.
+The only nonzero matrix element corresponds to `|↓↑⟩ <-- |↑↓⟩`.
+""" S_min_S_plus
+function S_min_S_plus(P::Type{<:Sector}, S::Type{<:Sector})
+    return S_min_S_plus(ComplexF64, P, S)
+end
+function S_min_S_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector})
+    return copy(adjoint(S_plus_S_min(elt, particle_symmetry, spin_symmetry)))
+end
+const S⁻S⁺ = S_min_S_plus
+
+@doc """
+    S_exchange(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the spin exchange operator S⋅S.
+""" S_exchange
+function S_exchange(P::Type{<:Sector}, S::Type{<:Sector})
+    return S_exchange(ComplexF64, P, S)
+end
+function S_exchange(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                    spin_symmetry::Type{<:Sector})
+    Sz = S_z(elt, particle_symmetry, spin_symmetry)
+    return (S_plus_S_min(elt, particle_symmetry, spin_symmetry)
+            +
+            S_min_S_plus(elt, particle_symmetry, spin_symmetry)) / 2 +
+           Sz ⊗ Sz
+end
+function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
+    t = two_site_operator(elt, Trivial, SU2Irrep)
+    for (s, f) in fusiontrees(t)
+        l3 = f.uncoupled[1][2].j
+        l4 = f.uncoupled[2][2].j
+        k = f.coupled[2].j
+        t[s, f] .= (k * (k + 1) - l3 * (l3 + 1) - l4 * (l4 + 1)) / 2
+    end
+    return t
+end
+function S_exchange(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    t = two_site_operator(elt, U1Irrep, SU2Irrep)
+    for (s, f) in fusiontrees(t)
+        l3 = f.uncoupled[1][3].j
+        l4 = f.uncoupled[2][3].j
+        k = f.coupled[3].j
+        t[s, f] .= (k * (k + 1) - l3 * (l3 + 1) - l4 * (l4 + 1)) / 2
+    end
+    return t
+end
 
 end

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -11,7 +11,7 @@ export u_min_d_min, d_min_u_min
 export e_plus_e_min, e_min_e_plus, singlet_min, e_hopping
 export S_plus_S_min, S_min_S_plus, S_exchange
 
-export nꜛ, nꜜ, nʰ, n
+export n, nꜛ, nꜜ, nꜛꜜ
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
 export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺, u⁻d⁻, d⁻u⁻
 export e⁺e⁻, e⁻e⁺, singlet⁻, e_hop

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -688,7 +688,7 @@ const S⁺S⁻ = S_plus_S_min
     S⁻S⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 
 Return the two-body operator S⁻S⁺.
-The only nonzero matrix element corresponds to `|↓↑⟩ <-- |↑↓⟩`.
+The only nonzero matrix element corresponds to `|↓,↑⟩ <-- |↑,↓⟩`.
 """ S_min_S_plus
 function S_min_S_plus(P::Type{<:Sector}, S::Type{<:Sector})
     return S_min_S_plus(ComplexF64, P, S)

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -244,7 +244,7 @@ function S_plus(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
     return t
 end
 function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
-    throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `U1Ireep` spin symmetry"))
+    throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `U1Irrep` spin symmetry"))
 end
 function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `SU2Irrep` spin symmetry"))

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -495,7 +495,7 @@ const d⁻d⁺ = d_min_d_plus
     u⁻d⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up particle at the first site and a spin-down particle at the second site.
-The only nonzero matrix element corresponds to `|00⟩ <-- |↑↓⟩`.
+The only nonzero matrix element corresponds to `|0,0⟩ <-- |↑,↓⟩`.
 """ u_min_d_min
 function u_min_d_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return u_min_d_min(ComplexF64, P, S; slave_fermion)
@@ -535,7 +535,7 @@ const u⁻d⁻ = u_min_d_min
     d⁻u⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down particle at the first site and a spin-up particle at the second site.
-The only nonzero matrix element corresponds to `|00⟩ <-- |↓↑⟩`.
+The only nonzero matrix element corresponds to `|0,0⟩ <-- |↓,↑⟩`.
 """ d_min_u_min
 function d_min_u_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return d_min_u_min(ComplexF64, P, S; slave_fermion)
@@ -675,7 +675,7 @@ const e_hop = e_hopping
     S⁺S⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator S⁺S⁻.
-The only nonzero matrix element corresponds to `|↑↓⟩ <-- |↓↑⟩`.
+The only nonzero matrix element corresponds to `|↑,↓⟩ <-- |↓,↑⟩`.
 """ S_plus_S_min
 function S_plus_S_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_plus_S_min(ComplexF64, P, S; slave_fermion)
@@ -719,7 +719,7 @@ const S⁺S⁻ = S_plus_S_min
     S⁻S⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
 Return the two-body operator S⁻S⁺.
-The only nonzero matrix element corresponds to `|↓↑⟩ <-- |↑↓⟩`.
+The only nonzero matrix element corresponds to `|↓,↑⟩ <-- |↑,↓⟩`.
 """ S_min_S_plus
 function S_min_S_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return S_min_S_plus(ComplexF64, P, S; slave_fermion)

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -598,30 +598,20 @@ function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep};
                       slave_fermion::Bool=false)
     t = two_site_operator(elt, Trivial, SU2Irrep; slave_fermion)
     I = sectortype(t)
-    if slave_fermion
-        f1 = only(fusiontrees((I(1, 0), I(0, 1 // 2)), I(1, 1 // 2)))
-        f2 = only(fusiontrees((I(0, 1 // 2), I(1, 0)), I(1, 1 // 2)))
-        t[f1, f2][1, 1, 1, 1] = 1
-    else
-        f1 = only(fusiontrees((I(0, 0), I(1, 1 // 2)), I(1, 1 // 2)))
-        f2 = only(fusiontrees((I(1, 1 // 2), I(0, 0)), I(1, 1 // 2)))
-        t[f1, f2][1, 1, 1, 1] = 1
-    end
+    (h, b) = slave_fermion ? (1, 0) : (0, 1)
+    f1 = only(fusiontrees((I(h, 0), I(b, 1 // 2)), I(1, 1 // 2)))
+    f2 = only(fusiontrees((I(b, 1 // 2), I(h, 0)), I(1, 1 // 2)))
+    t[f1, f2][1, 1, 1, 1] = 1
     return t
 end
 function e_plus_e_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
                       slave_fermion::Bool=false)
     t = two_site_operator(elt, U1Irrep, SU2Irrep; slave_fermion)
     I = sectortype(t)
-    if slave_fermion
-        f1 = only(fusiontrees((I(1, 0, 0), I(0, 1, 1 // 2)), I(1, 1, 1 // 2)))
-        f2 = only(fusiontrees((I(0, 1, 1 // 2), I(1, 0, 0)), I(1, 1, 1 // 2)))
-        t[f1, f2][1, 1, 1, 1] = 1
-    else
-        f1 = only(fusiontrees((I(0, 0, 0), I(1, 1, 1 // 2)), I(1, 1, 1 // 2)))
-        f2 = only(fusiontrees((I(1, 1, 1 // 2), I(0, 0, 0)), I(1, 1, 1 // 2)))
-        t[f1, f2][1, 1, 1, 1] = 1
-    end
+    (h, b) = slave_fermion ? (1, 0) : (0, 1)
+    f1 = only(fusiontrees((I(h, 0, 0), I(b, 1, 1 // 2)), I(1, 1, 1 // 2)))
+    f2 = only(fusiontrees((I(b, 1, 1 // 2), I(h, 0, 0)), I(1, 1, 1 // 2)))
+    t[f1, f2][1, 1, 1, 1] = 1
     return t
 end
 

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -524,10 +524,6 @@ function u_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
                      slave_fermion::Bool=false)
     throw(ArgumentError("`u_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
-                     slave_fermion::Bool=false)
-    throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` spin symmetry"))
-end
 const u⁻d⁻ = u_min_d_min
 
 @doc """
@@ -563,10 +559,6 @@ end
 function d_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
                      slave_fermion::Bool=false)
     throw(ArgumentError("`d_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
-end
-function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
-                     slave_fermion::Bool=false)
-    throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
 

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -263,6 +263,14 @@ function S_plus(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
     t[(I(b, 1), dual(I(b, 1)))][1, 2] = 1.0
     return t
 end
+function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep};
+                slave_fermion::Bool=false)
+    throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `U1Ireep` spin symmetry"))
+end
+function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
+                slave_fermion::Bool=false)
+    throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `SU2Irrep` spin symmetry"))
+end
 const S⁺ = S_plus
 
 @doc """

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -524,6 +524,10 @@ function u_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
                      slave_fermion::Bool=false)
     throw(ArgumentError("`u_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
+function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` spin symmetry"))
+end
 const u⁻d⁻ = u_min_d_min
 
 @doc """
@@ -559,6 +563,10 @@ end
 function d_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
                      slave_fermion::Bool=false)
     throw(ArgumentError("`d_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
+end
+function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
 

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -265,7 +265,7 @@ function S_plus(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial};
 end
 function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep};
                 slave_fermion::Bool=false)
-    throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `U1Ireep` spin symmetry"))
+    throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `U1Irrep` spin symmetry"))
 end
 function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
                 slave_fermion::Bool=false)

--- a/test/fermionoperators.jl
+++ b/test/fermionoperators.jl
@@ -11,12 +11,12 @@ using StableRNGs
 # {fᵢ, fⱼ†} = δᵢⱼ
 
 @testset "simple fermions" begin
-    @test f⁻f⁻() ≈ -permute(f⁻f⁻(), ((2, 1), (4, 3)))
-    @test f⁺f⁺() ≈ -permute(f⁺f⁺(), ((2, 1), (4, 3)))
+    @test f⁻f⁻() ≈ -swap_2sites(f⁻f⁻())
+    @test f⁺f⁺() ≈ -swap_2sites(f⁺f⁺())
 
     # the following doesn't hold
     # I don't think I can get all of these to hold simultaneously?
-    # @test ff⁺ ≈ -permute(f⁺f, (2, 1), (4, 3))
+    # @test ff⁺ ≈ -swap_2sites(f⁺f)
 
     @test f⁻f⁺()' ≈ -f⁺f⁻()
     @test f⁻f⁻()' ≈ f⁺f⁺()

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -131,7 +131,7 @@ function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu, L)
     hopping = -t * (e_plus_e_min(particle_symmetry, spin_symmetry) -
                     e_min_e_plus(particle_symmetry, spin_symmetry))
     interaction = U * ud_num(particle_symmetry, spin_symmetry)
-    chemical_potential = mu * e_num(particle_symmetry, spin_symmetry)
+    chemical_potential = -mu * e_num(particle_symmetry, spin_symmetry)
     I = id(hubbard_space(particle_symmetry, spin_symmetry))
     H = sum(1:(L - 1)) do i
             return reduce(⊗, insert!(collect(Any, fill(I, L - 2)), i, hopping))

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -52,6 +52,11 @@ end
                       d_min_d_plus(particle_symmetry, spin_symmetry)
                 @test u_plus_u_min(particle_symmetry, spin_symmetry)' ≈
                       u_min_u_plus(particle_symmetry, spin_symmetry)
+            else
+                @test_throws ArgumentError u_plus_u_min(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError u_min_u_plus(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError d_plus_d_min(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError d_min_d_plus(particle_symmetry, spin_symmetry)
             end
 
             # test number operator
@@ -64,9 +69,6 @@ end
                       d_num(particle_symmetry, spin_symmetry) ≈
                       d_num(particle_symmetry, spin_symmetry) *
                       u_num(particle_symmetry, spin_symmetry)
-            else
-                @test_throws ArgumentError u_plus_u_min(particle_symmetry, spin_symmetry)
-                @test_throws ArgumentError d_plus_d_min(particle_symmetry, spin_symmetry)
             end
 
             # test singlet operator
@@ -116,6 +118,14 @@ end
                 for i in 1:3, j in 1:3
                     @test Svec[i] * Svec[j] - Svec[j] * Svec[i] ≈
                           sum(im * ε[i, j, k] * Svec[k] for k in 1:3)
+                end
+            else
+                @test_throws ArgumentError S_plus(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError S_min(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError S_x(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError S_y(particle_symmetry, spin_symmetry)
+                if spin_symmetry != U1Irrep
+                    @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry)
                 end
             end
         else

--- a/test/testsetup.jl
+++ b/test/testsetup.jl
@@ -1,6 +1,6 @@
 module TensorKitTensorsTestSetup
 
-export test_operator, operator_sum, expanded_eigenvalues
+export test_operator, operator_sum, swap_2sites, expanded_eigenvalues
 
 using Test
 using TensorKit
@@ -13,6 +13,10 @@ function operator_sum(O::AbstractTensorMap; L::Int=4)
     return sum(1:(L - n + 1)) do i
         return reduce(⊗, insert!(collect(Any, fill(I, L - n)), i, O))
     end
+end
+
+function swap_2sites(op::AbstractTensorMap{T,S,2,2}) where {T,S}
+    return permute(op, ((2, 1), (4, 3)))
 end
 
 function test_operator(O1::AbstractTensorMap, O2::AbstractTensorMap; L::Int=4,

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -40,6 +40,7 @@ end
             spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
 
             if (particle_symmetry, spin_symmetry) in implemented_symmetries
+                pspace = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
                 # test hermiticity
                 @test e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
                       -e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)
@@ -71,9 +72,9 @@ end
                     @test u_num(particle_symmetry, spin_symmetry; slave_fermion) *
                           d_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
                           d_num(particle_symmetry, spin_symmetry; slave_fermion) *
-                          u_num(particle_symmetry, spin_symmetry; slave_fermion)
-                    @test TensorKit.id(tj_space(particle_symmetry, spin_symmetry;
-                                                slave_fermion)) ≈
+                          u_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                          zeros(pspace ← pspace)
+                    @test TensorKit.id(pspace) ≈
                           h_num(particle_symmetry, spin_symmetry; slave_fermion) +
                           e_num(particle_symmetry, spin_symmetry; slave_fermion)
                 else
@@ -135,6 +136,19 @@ end
                     for i in 1:3, j in 1:3
                         @test Svec[i] * Svec[j] - Svec[j] * Svec[i] ≈
                               sum(im * ε[i, j, k] * Svec[k] for k in 1:3)
+                    end
+                else
+                    @test_throws ArgumentError S_plus(particle_symmetry, spin_symmetry;
+                                                      slave_fermion)
+                    @test_throws ArgumentError S_min(particle_symmetry, spin_symmetry;
+                                                     slave_fermion)
+                    @test_throws ArgumentError S_x(particle_symmetry, spin_symmetry;
+                                                   slave_fermion)
+                    @test_throws ArgumentError S_y(particle_symmetry, spin_symmetry;
+                                                   slave_fermion)
+                    if spin_symmetry != U1Irrep
+                        @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry;
+                                                       slave_fermion)
                     end
                 end
             else

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -10,156 +10,159 @@ implemented_symmetries = [(Trivial, Trivial), (Trivial, U1Irrep), (Trivial, SU2I
                           (U1Irrep, Trivial), (U1Irrep, U1Irrep), (U1Irrep, SU2Irrep)]
 
 @testset "Compare symmetric with trivial tensors" begin
-    for particle_symmetry in [Trivial, U1Irrep],
+    for slave_fermion in (false, true),
+        particle_symmetry in [Trivial, U1Irrep],
         spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
 
-        for slave_fermion in (false, true)
-            if (particle_symmetry, spin_symmetry) in implemented_symmetries
-                space = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
+        if (particle_symmetry, spin_symmetry) in implemented_symmetries
+            space = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
 
-                O = e_plus_e_min(ComplexF64, particle_symmetry, spin_symmetry;
-                                 slave_fermion)
-                O_triv = e_plus_e_min(ComplexF64, Trivial, Trivial; slave_fermion)
-                test_operator(O, O_triv)
+            O = e_plus_e_min(ComplexF64, particle_symmetry, spin_symmetry;
+                             slave_fermion)
+            O_triv = e_plus_e_min(ComplexF64, Trivial, Trivial; slave_fermion)
+            test_operator(O, O_triv)
 
-                O = e_num(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
-                O_triv = e_num(ComplexF64, Trivial, Trivial; slave_fermion)
-                test_operator(O, O_triv)
+            O = e_num(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
+            O_triv = e_num(ComplexF64, Trivial, Trivial; slave_fermion)
+            test_operator(O, O_triv)
 
-            else
-                @test_broken e_plus_e_min(ComplexF64, particle_symmetry, spin_symmetry)
-                @test_broken e_num(ComplexF64, particle_symmetry, spin_symmetry)
-            end
+            O = S_exchange(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
+            O_triv = S_exchange(ComplexF64, Trivial, Trivial; slave_fermion)
+            test_operator(O, O_triv)
+        else
+            @test_broken e_plus_e_min(ComplexF64, particle_symmetry, spin_symmetry;
+                                      slave_fermion)
+            @test_broken e_num(ComplexF64, particle_symmetry, spin_symmetry;
+                               slave_fermion)
+            @test_broken S_exchange(ComplexF64, particle_symmetry, spin_symmetry;
+                                    slave_fermion)
         end
     end
 end
 
 @testset "basic properties" begin
-    for slave_fermion in (false, true)
-        for particle_symmetry in [Trivial, U1Irrep],
-            spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
+    for slave_fermion in (false, true),
+        particle_symmetry in [Trivial, U1Irrep],
+        spin_symmetry in [Trivial, U1Irrep, SU2Irrep]
 
-            if (particle_symmetry, spin_symmetry) in implemented_symmetries
+        if (particle_symmetry, spin_symmetry) in implemented_symmetries
+            # test hopping operator
+            epem = e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion)
+            emep = e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)
+            @test epem' ≈ -emep ≈ swap_2sites(epem)
+            if spin_symmetry !== SU2Irrep
+                dpdm = d_plus_d_min(particle_symmetry, spin_symmetry)
+                dmdp = d_min_d_plus(particle_symmetry, spin_symmetry)
+                @test dpdm' ≈ -dmdp ≈ swap_2sites(dpdm)
+                upum = u_plus_u_min(particle_symmetry, spin_symmetry)
+                umup = u_min_u_plus(particle_symmetry, spin_symmetry)
+                @test upum' ≈ -umup ≈ swap_2sites(upum)
+            else
+                @test_throws ArgumentError d_plus_d_min(particle_symmetry,
+                                                        spin_symmetry;
+                                                        slave_fermion)
+                @test_throws ArgumentError d_min_d_plus(particle_symmetry,
+                                                        spin_symmetry;
+                                                        slave_fermion)
+                @test_throws ArgumentError u_plus_u_min(particle_symmetry,
+                                                        spin_symmetry;
+                                                        slave_fermion)
+                @test_throws ArgumentError u_min_u_plus(particle_symmetry,
+                                                        spin_symmetry;
+                                                        slave_fermion)
+            end
+
+            # test number operator
+            if spin_symmetry !== SU2Irrep
                 pspace = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
-                # test hermiticity
-                @test e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
-                      -e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                if spin_symmetry !== SU2Irrep
-                    @test d_plus_d_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
-                          -d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                    @test u_plus_u_min(particle_symmetry, spin_symmetry; slave_fermion)' ≈
-                          -u_min_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                else
-                    @test_throws ArgumentError d_plus_d_min(particle_symmetry,
-                                                            spin_symmetry;
-                                                            slave_fermion)
-                    @test_throws ArgumentError d_min_d_plus(particle_symmetry,
-                                                            spin_symmetry;
-                                                            slave_fermion)
-                    @test_throws ArgumentError u_plus_u_min(particle_symmetry,
-                                                            spin_symmetry;
-                                                            slave_fermion)
-                    @test_throws ArgumentError u_min_u_plus(particle_symmetry,
-                                                            spin_symmetry;
-                                                            slave_fermion)
-                end
+                @test e_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                      u_num(particle_symmetry, spin_symmetry; slave_fermion) +
+                      d_num(particle_symmetry, spin_symmetry; slave_fermion)
+                @test u_num(particle_symmetry, spin_symmetry; slave_fermion) *
+                      d_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                      d_num(particle_symmetry, spin_symmetry; slave_fermion) *
+                      u_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                      zeros(pspace ← pspace)
+                @test TensorKit.id(pspace) ≈
+                      h_num(particle_symmetry, spin_symmetry; slave_fermion) +
+                      e_num(particle_symmetry, spin_symmetry; slave_fermion)
+            else
+                @test_throws ArgumentError u_num(particle_symmetry, spin_symmetry;
+                                                 slave_fermion)
+                @test_throws ArgumentError d_num(particle_symmetry, spin_symmetry;
+                                                 slave_fermion)
+            end
 
-                # test number operator
-                if spin_symmetry !== SU2Irrep
-                    @test e_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                          u_num(particle_symmetry, spin_symmetry; slave_fermion) +
-                          d_num(particle_symmetry, spin_symmetry; slave_fermion)
-                    @test u_num(particle_symmetry, spin_symmetry; slave_fermion) *
-                          d_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                          d_num(particle_symmetry, spin_symmetry; slave_fermion) *
-                          u_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                          zeros(pspace ← pspace)
-                    @test TensorKit.id(pspace) ≈
-                          h_num(particle_symmetry, spin_symmetry; slave_fermion) +
-                          e_num(particle_symmetry, spin_symmetry; slave_fermion)
-                else
-                    @test_throws ArgumentError u_num(particle_symmetry, spin_symmetry;
-                                                     slave_fermion)
-                    @test_throws ArgumentError d_num(particle_symmetry, spin_symmetry;
-                                                     slave_fermion)
-                end
-
-                # test singlet operator
-                if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
-                    sing = singlet_min(particle_symmetry, spin_symmetry;
-                                       slave_fermion)
-                    ud = u_min_d_min(particle_symmetry, spin_symmetry;
-                                     slave_fermion)
-                    du = d_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
-                    @test permute(ud, ((2, 1), (4, 3))) ≈ -du
-                    @test permute(sing, ((2, 1), (4, 3))) ≈ sing
-                    @test sing ≈ (ud - du) / sqrt(2)
-                else
-                    @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry;
-                                                           slave_fermion)
-                    @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry;
-                                                           slave_fermion)
-                    @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry;
-                                                           slave_fermion)
-                end
-
-                # test hopping operator
-                @test e_hopping(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                      e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion) -
-                      e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)
-
-                # test spin operator
-                if spin_symmetry == Trivial
-                    ε = zeros(ComplexF64, 3, 3, 3)
-                    for i in 1:3
-                        ε[mod1(i, 3), mod1(i + 1, 3), mod1(i + 2, 3)] = 1
-                        ε[mod1(i, 3), mod1(i - 1, 3), mod1(i - 2, 3)] = -1
-                    end
-                    Svec = [S_x(particle_symmetry, spin_symmetry; slave_fermion),
-                            S_y(particle_symmetry, spin_symmetry; slave_fermion),
-                            S_z(particle_symmetry, spin_symmetry; slave_fermion)]
-                    # Hermiticity
-                    for s in Svec
-                        @test s' ≈ s
-                    end
-                    # operators should be normalized
-                    S = 1 / 2
-                    @test sum(tr(Svec[i]^2) for i in 1:3) / (2S + 1) ≈ S * (S + 1)
-                    # test S_plus and S_min
-                    @test S_plus_S_min(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                          S_plus(particle_symmetry, spin_symmetry; slave_fermion) ⊗
-                          S_min(particle_symmetry, spin_symmetry; slave_fermion)
-                    @test S_min_S_plus(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                          S_min(particle_symmetry, spin_symmetry; slave_fermion) ⊗
-                          S_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                    # commutation relations
-                    for i in 1:3, j in 1:3
-                        @test Svec[i] * Svec[j] - Svec[j] * Svec[i] ≈
-                              sum(im * ε[i, j, k] * Svec[k] for k in 1:3)
-                    end
-                else
-                    @test_throws ArgumentError S_plus(particle_symmetry, spin_symmetry;
-                                                      slave_fermion)
-                    @test_throws ArgumentError S_min(particle_symmetry, spin_symmetry;
-                                                     slave_fermion)
-                    @test_throws ArgumentError S_x(particle_symmetry, spin_symmetry;
-                                                   slave_fermion)
-                    @test_throws ArgumentError S_y(particle_symmetry, spin_symmetry;
-                                                   slave_fermion)
-                    if spin_symmetry != U1Irrep
-                        @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry;
+            # test singlet operator
+            if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
+                sing = singlet_min(particle_symmetry, spin_symmetry;
+                                   slave_fermion)
+                ud = u_min_d_min(particle_symmetry, spin_symmetry;
+                                 slave_fermion)
+                du = d_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
+                @test swap_2sites(ud) ≈ -du
+                @test swap_2sites(sing) ≈ sing
+                @test sing ≈ (ud - du) / sqrt(2)
+            else
+                @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry;
                                                        slave_fermion)
-                    end
+                @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry;
+                                                       slave_fermion)
+                @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry;
+                                                       slave_fermion)
+            end
+
+            # test spin operator
+            if spin_symmetry == Trivial
+                ε = zeros(ComplexF64, 3, 3, 3)
+                for i in 1:3
+                    ε[mod1(i, 3), mod1(i + 1, 3), mod1(i + 2, 3)] = 1
+                    ε[mod1(i, 3), mod1(i - 1, 3), mod1(i - 2, 3)] = -1
+                end
+                Svec = [S_x(particle_symmetry, spin_symmetry; slave_fermion),
+                        S_y(particle_symmetry, spin_symmetry; slave_fermion),
+                        S_z(particle_symmetry, spin_symmetry; slave_fermion)]
+                # Hermiticity
+                for s in Svec
+                    @test s' ≈ s
+                end
+                # operators should be normalized
+                S = 1 / 2
+                @test sum(tr(Svec[i]^2) for i in 1:3) / (2S + 1) ≈ S * (S + 1)
+                # test S_plus and S_min
+                @test S_plus_S_min(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                      S_plus(particle_symmetry, spin_symmetry; slave_fermion) ⊗
+                      S_min(particle_symmetry, spin_symmetry; slave_fermion)
+                @test S_min_S_plus(particle_symmetry, spin_symmetry; slave_fermion) ≈
+                      S_min(particle_symmetry, spin_symmetry; slave_fermion) ⊗
+                      S_plus(particle_symmetry, spin_symmetry; slave_fermion)
+                # commutation relations
+                for i in 1:3, j in 1:3
+                    @test Svec[i] * Svec[j] - Svec[j] * Svec[i] ≈
+                          sum(im * ε[i, j, k] * Svec[k] for k in 1:3)
                 end
             else
-                @test_broken d_plus_d_min(particle_symmetry, spin_symmetry; slave_fermion)
-                @test_broken d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                @test_broken u_plus_u_min(particle_symmetry, spin_symmetry; slave_fermion)
-                @test_broken u_min_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                @test_broken e_num(particle_symmetry, spin_symmetry; slave_fermion)
-                @test_broken u_num(particle_symmetry, spin_symmetry; slave_fermion)
-                @test_broken d_num(particle_symmetry, spin_symmetry; slave_fermion)
+                @test_throws ArgumentError S_plus(particle_symmetry, spin_symmetry;
+                                                  slave_fermion)
+                @test_throws ArgumentError S_min(particle_symmetry, spin_symmetry;
+                                                 slave_fermion)
+                @test_throws ArgumentError S_x(particle_symmetry, spin_symmetry;
+                                               slave_fermion)
+                @test_throws ArgumentError S_y(particle_symmetry, spin_symmetry;
+                                               slave_fermion)
+                if spin_symmetry != U1Irrep
+                    @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry;
+                                                   slave_fermion)
+                end
             end
+        else
+            @test_broken d_plus_d_min(particle_symmetry, spin_symmetry; slave_fermion)
+            @test_broken d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
+            @test_broken u_plus_u_min(particle_symmetry, spin_symmetry; slave_fermion)
+            @test_broken u_min_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
+            @test_broken e_num(particle_symmetry, spin_symmetry; slave_fermion)
+            @test_broken u_num(particle_symmetry, spin_symmetry; slave_fermion)
+            @test_broken d_num(particle_symmetry, spin_symmetry; slave_fermion)
         end
     end
 end


### PR DESCRIPTION
This PR adds spin and singlet operators to HubbardOperators.

- The spin operators are defined as $S^a_i = c^\dagger_{i\alpha} \sigma^a_{\alpha \beta} c_{i\beta} / 2$ (a = x, y, z). Their nonzero matrix elements are the same as their counterpart in t-J model (they don't have nonzero elements relevant to the doubly-occupied state). 
- The singlet operator is still defined as $\epsilon_{\alpha \beta} c_{i\alpha} c_{j\beta}$. It actually have SU(2) spin symmetry, which remains to be added for both t-J and Hubbard models.

In addition, the definition of `u_min_u_plus`, `d_min_d_plus` in `HubbardOperators` are changed to be consistent with #15, which was overlooked there. This will then close issue #17.

TODO:

- [x] Add test to ensure that two-body `S_plus_S_min` (and its h.c.) and `S_exchange` with non-trivial spin symmetry is correctly defined now that the physical space has the doubly-occupied state. 