### PR TITLE
Add `u_min_u_min`, `d_min_d_min` for tJ/Hubbard

### DIFF
--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -17,7 +17,8 @@ export S_plus_S_min, S_min_S_plus, S_exchange
 export n, nꜛ, nꜜ, nꜛꜜ
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
 export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
-export u⁻d⁻, d⁻u⁻, u⁻u⁻, d⁻d⁻
+export u⁻d⁻, d⁻u⁻
+export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
 export singlet⁻
 export S⁻S⁺, S⁺S⁻

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -9,6 +9,7 @@ export u_plus_u_min, d_plus_d_min
 export u_min_u_plus, d_min_d_plus
 export u_min_d_min, d_min_u_min
 export u_min_u_min, d_min_d_min
+export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
 export singlet_min
 export S_plus_S_min, S_min_S_plus, S_exchange

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -12,7 +12,7 @@ export u_plus_d_plus, d_plus_u_plus
 export u_min_u_min, d_min_d_min
 export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
-export singlet_min
+export singlet_plus, singlet_min
 export S_plus_S_min, S_min_S_plus, S_exchange
 
 export n, nꜛ, nꜜ, nꜛꜜ
@@ -21,7 +21,7 @@ export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
 export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
 export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
-export singlet⁻
+export singlet⁺, singlet⁻
 export S⁻S⁺, S⁺S⁻
 
 """
@@ -782,18 +782,35 @@ end
 const d⁺d⁺ = d_plus_d_plus
 
 @doc """
+    singlet_plus(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    singlet⁺(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / sqrt(2)``,
+which creates the singlet state when acting on vaccum.
+""" singlet_plus
+function singlet_plus(P::Type{<:Sector}, S::Type{<:Sector})
+    return singlet_plus(ComplexF64, P, S)
+end
+function singlet_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector})
+    return (u_plus_d_plus(elt, particle_symmetry, spin_symmetry) -
+            d_plus_u_plus(elt, particle_symmetry, spin_symmetry)) / sqrt(2)
+end
+const singlet⁺ = singlet_plus
+
+@doc """
     singlet_min(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
     singlet⁻(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 
-Return the two-body singlet operator ``(e_{1,↓} e_{2,↑} - e_{1,↓} e_{2,↑}) / sqrt(2)``.
+Return the adjoint of `singlet_plus` operator, which is 
+``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / sqrt(2)``
 """ singlet_min
 function singlet_min(P::Type{<:Sector}, S::Type{<:Sector})
     return singlet_min(ComplexF64, P, S)
 end
 function singlet_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
                      spin_symmetry::Type{<:Sector})
-    return (u_min_d_min(elt, particle_symmetry, spin_symmetry) -
-            d_min_u_min(elt, particle_symmetry, spin_symmetry)) / sqrt(2)
+    return copy(adjoint(singlet_plus(elt, particle_symmetry, spin_symmetry)))
 end
 const singlet⁻ = singlet_min
 

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -8,6 +8,7 @@ export S_x, S_y, S_z, S_plus, S_min
 export u_plus_u_min, d_plus_d_min
 export u_min_u_plus, d_min_d_plus
 export u_min_d_min, d_min_u_min
+export u_plus_d_plus, d_plus_u_plus
 export u_min_u_min, d_min_d_min
 export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
@@ -17,7 +18,7 @@ export S_plus_S_min, S_min_S_plus, S_exchange
 export n, nꜛ, nꜜ, nꜛꜜ
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
 export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
-export u⁻d⁻, d⁻u⁻
+export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
 export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
 export singlet⁻
@@ -597,6 +598,21 @@ end
 const u⁻d⁻ = u_min_d_min
 
 @doc """
+    u_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    u⁺d⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that annihilates a spin-up particle at the first site and a spin-down particle at the second site.
+""" u_plus_d_plus
+function u_plus_d_plus(P::Type{<:Sector}, S::Type{<:Sector})
+    return u_plus_d_plus(ComplexF64, P, S)
+end
+function u_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                       spin_symmetry::Type{<:Sector})
+    return -copy(adjoint(u_min_d_min(elt, particle_symmetry, spin_symmetry)))
+end
+const u⁺d⁺ = u_plus_d_plus
+
+@doc """
     d_min_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
     d⁻u⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 
@@ -638,6 +654,21 @@ function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
+
+@doc """
+    d_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    d⁺u⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down particle at the first site and a spin-up particle at the second site.
+""" d_plus_u_plus
+function d_plus_u_plus(P::Type{<:Sector}, S::Type{<:Sector})
+    return d_plus_u_plus(ComplexF64, P, S)
+end
+function d_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                       spin_symmetry::Type{<:Sector})
+    return -copy(adjoint(d_min_u_min(elt, particle_symmetry, spin_symmetry)))
+end
+const d⁺u⁺ = d_plus_u_plus
 
 @doc """
     u_min_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -734,6 +734,22 @@ end
 const d⁻d⁻ = d_min_d_min
 
 @doc """
+    d_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    d⁺d⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down particle at both sites.
+The nonzero matrix elements are
+""" d_plus_d_plus
+function d_plus_d_plus(P::Type{<:Sector}, S::Type{<:Sector})
+    return d_plus_d_plus(ComplexF64, P, S)
+end
+function d_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector})
+    return -copy(adjoint(d_min_d_min(elt, particle_symmetry, spin_symmetry)))
+end
+const d⁺d⁺ = d_plus_d_plus
+
+@doc """
     singlet_min(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
     singlet⁻(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -678,6 +678,21 @@ end
 const u⁻u⁻ = u_min_u_min
 
 @doc """
+    u_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    u⁺u⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up particle at both sites.
+""" u_plus_u_plus
+function u_plus_u_plus(P::Type{<:Sector}, S::Type{<:Sector})
+    return u_plus_u_plus(ComplexF64, P, S)
+end
+function u_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector})
+    return -copy(adjoint(u_min_u_min(elt, particle_symmetry, spin_symmetry)))
+end
+const u⁺u⁺ = u_plus_u_plus
+
+@doc """
     d_min_d_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
     d⁻d⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -689,7 +689,7 @@ function u_plus_u_plus(P::Type{<:Sector}, S::Type{<:Sector})
     return u_plus_u_plus(ComplexF64, P, S)
 end
 function u_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
-                      spin_symmetry::Type{<:Sector})
+                       spin_symmetry::Type{<:Sector})
     return -copy(adjoint(u_min_u_min(elt, particle_symmetry, spin_symmetry)))
 end
 const u⁺u⁺ = u_plus_u_plus
@@ -745,7 +745,7 @@ function d_plus_d_plus(P::Type{<:Sector}, S::Type{<:Sector})
     return d_plus_d_plus(ComplexF64, P, S)
 end
 function d_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
-                      spin_symmetry::Type{<:Sector})
+                       spin_symmetry::Type{<:Sector})
     return -copy(adjoint(d_min_d_min(elt, particle_symmetry, spin_symmetry)))
 end
 const d⁺d⁺ = d_plus_d_plus

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -8,13 +8,17 @@ export S_x, S_y, S_z, S_plus, S_min
 export u_plus_u_min, d_plus_d_min
 export u_min_u_plus, d_min_d_plus
 export u_min_d_min, d_min_u_min
-export e_plus_e_min, e_min_e_plus, singlet_min, e_hopping
+export u_min_u_min, d_min_d_min
+export e_plus_e_min, e_min_e_plus, e_hopping
+export singlet_min
 export S_plus_S_min, S_min_S_plus, S_exchange
 
 export n, nꜛ, nꜜ, nꜛꜜ
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
-export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺, u⁻d⁻, d⁻u⁻
-export e⁺e⁻, e⁻e⁺, singlet⁻, e_hop
+export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
+export u⁻d⁻, d⁻u⁻, u⁻u⁻, d⁻d⁻
+export e⁺e⁻, e⁻e⁺, e_hop
+export singlet⁻
 export S⁻S⁺, S⁺S⁻
 
 """
@@ -632,6 +636,86 @@ function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
+
+@doc """
+    u_min_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    u⁻u⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator ``e_{1,↑} e_{2,↑}`` that annihilates a spin-up particle at both sites.
+The nonzero matrix elements are
+```
+    -|0,0⟩ ↤ |↑,↑⟩,     -|0,↓⟩ ↤ |↑,↑↓⟩
+    +|↓,0⟩ ↤ |↑↓,↑⟩,    +|↓,↓⟩ ↤ |↑↓,↑↓⟩
+```
+""" u_min_u_min
+function u_min_u_min(P::Type{<:Sector}, S::Type{<:Sector})
+    return u_min_u_min(ComplexF64, P, S)
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    t = two_site_operator(elt, Trivial, Trivial)
+    I = sectortype(t)
+    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 1] = -1
+    t[(I(0), I(1), dual(I(1)), dual(I(0)))][1, 2, 1, 2] = -1
+    t[(I(1), I(0), dual(I(0)), dual(I(1)))][2, 1, 2, 1] = 1
+    t[(I(1), I(1), dual(I(0)), dual(I(0)))][2, 2, 2, 2] = 1
+    return t
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry"))
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` spin symmetry"))
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `U1Irrep` particle symmetry"))
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
+end
+const u⁻u⁻ = u_min_u_min
+
+@doc """
+    d_min_d_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    d⁻d⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+
+Return the two-body operator ``e_{1,↓} e_{2,↓}`` that annihilates a spin-down particle at both sites.
+The nonzero matrix elements are
+```
+    -|0,0⟩ ↤ |↓,↓⟩,     +|0,↑⟩ ↤ |↓,↑↓⟩
+    -|↑,0⟩ ↤ |↑↓,↓⟩,    +|↑,↑⟩ ↤ |↑↓,↑↓⟩
+```
+""" d_min_d_min
+function d_min_d_min(P::Type{<:Sector}, S::Type{<:Sector})
+    return d_min_d_min(ComplexF64, P, S)
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    t = two_site_operator(elt, Trivial, Trivial)
+    I = sectortype(t)
+    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 2] = -1
+    t[(I(0), I(1), dual(I(1)), dual(I(0)))][1, 1, 2, 2] = 1
+    t[(I(1), I(0), dual(I(0)), dual(I(1)))][1, 1, 2, 2] = -1
+    t[(I(1), I(1), dual(I(0)), dual(I(0)))][1, 1, 2, 2] = 1
+    return t
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry"))
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` spin symmetry"))
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `U1Irrep` particle symmetry"))
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
+end
+const d⁻d⁻ = d_min_d_min
 
 @doc """
     singlet_min(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -9,6 +9,7 @@ export u_plus_u_min, d_plus_d_min
 export u_min_u_plus, d_min_d_plus
 export u_min_d_min, d_min_u_min
 export u_min_u_min, d_min_d_min
+export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
 export singlet_min
 export S_plus_S_min, S_min_S_plus, S_exchange

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -8,13 +8,17 @@ export S_x, S_y, S_z, S_plus, S_min
 export u_plus_u_min, d_plus_d_min
 export u_min_u_plus, d_min_d_plus
 export u_min_d_min, d_min_u_min
-export e_plus_e_min, e_min_e_plus, singlet_min, e_hopping
+export u_min_u_min, d_min_d_min
+export e_plus_e_min, e_min_e_plus, e_hopping
+export singlet_min
 export S_plus_S_min, S_min_S_plus, S_exchange
 
 export nꜛ, nꜜ, nʰ, n
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
-export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺, u⁻d⁻, d⁻u⁻
-export e⁺e⁻, e⁻e⁺, singlet⁻, e_hop
+export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
+export u⁻d⁻, d⁻u⁻, u⁻u⁻, d⁻d⁻
+export e⁺e⁻, e⁻e⁺, e_hop
+export singlet⁻
 export S⁻S⁺, S⁺S⁻
 
 """
@@ -577,6 +581,86 @@ function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
+
+@doc """
+    u_min_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    u⁻u⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+
+Return the two-body operator ``e_{1,↑} e_{2,↑}`` that annihilates a spin-up particle at both sites.
+The only nonzero matrix element corresponds to `|0,0⟩ <-- |↑,↑⟩`.
+""" u_min_u_min
+function u_min_u_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return u_min_u_min(ComplexF64, P, S; slave_fermion)
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+                     slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
+    I = sectortype(t)
+    (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
+    t[(I(h), I(h), dual(I(b)), dual(I(b)))][1, 1, 1, 1] = -sgn * 1
+    return t
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry"))
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` spin symmetry"))
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `U1Irrep` particle symmetry"))
+end
+function u_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
+end
+const u⁻u⁻ = u_min_u_min
+
+@doc """
+    d_min_d_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    d⁻d⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+
+Return the two-body operator ``e_{1,↓} e_{2,↓}`` that annihilates a spin-down particle at both sites.
+The only nonzero matrix element corresponds to `|0,0⟩ <-- |↓,↓⟩`.
+""" d_min_d_min
+function d_min_d_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return d_min_d_min(ComplexF64, P, S; slave_fermion)
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+                     slave_fermion::Bool=false)
+    t = two_site_operator(elt, Trivial, Trivial; slave_fermion)
+    I = sectortype(t)
+    (h, b, sgn) = slave_fermion ? (1, 0, -1) : (0, 1, 1)
+    t[(I(h), I(h), dual(I(b)), dual(I(b)))][1, 1, 2, 2] = -sgn * 1
+    return t
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry"))
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` spin symmetry"))
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `U1Irrep` particle symmetry"))
+end
+function d_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
+                     slave_fermion::Bool=false)
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
+end
+const d⁻d⁻ = d_min_d_min
 
 @doc """
     e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -545,6 +545,22 @@ end
 const u⁻d⁻ = u_min_d_min
 
 @doc """
+    u_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    u⁺d⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that annihilates a spin-up particle at the first site and a spin-down particle at the second site.
+""" u_plus_d_plus
+function u_plus_d_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return u_plus_d_plus(ComplexF64, P, S; slave_fermion)
+end
+function u_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                       spin_symmetry::Type{<:Sector};
+                       slave_fermion::Bool=false)
+    return -copy(adjoint(u_min_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
+end
+const u⁺d⁺ = u_plus_d_plus
+
+@doc """
     d_min_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
     d⁻u⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
@@ -583,6 +599,22 @@ function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep};
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
+
+@doc """
+    d_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    d⁺u⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that annihilates a spin-down particle at the first site and a spin-up particle at the second site.
+""" d_plus_u_plus
+function d_plus_u_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return d_plus_u_plus(ComplexF64, P, S; slave_fermion)
+end
+function d_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                       spin_symmetry::Type{<:Sector};
+                       slave_fermion::Bool=false)
+    return -copy(adjoint(d_min_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
+end
+const d⁺u⁺ = d_plus_u_plus
 
 @doc """
     u_min_u_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -665,6 +665,22 @@ end
 const d⁻d⁻ = d_min_d_min
 
 @doc """
+    d_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    d⁺d⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that annihilates a spin-down particle at both sites.
+""" d_plus_d_plus
+function d_plus_d_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return d_plus_d_plus(ComplexF64, P, S; slave_fermion)
+end
+function d_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector};
+                      slave_fermion::Bool=false)
+    return -copy(adjoint(d_min_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
+end
+const d⁺d⁺ = d_plus_d_plus
+
+@doc """
     e_plus_e_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
     e⁺e⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -8,6 +8,7 @@ export S_x, S_y, S_z, S_plus, S_min
 export u_plus_u_min, d_plus_d_min
 export u_min_u_plus, d_min_d_plus
 export u_min_d_min, d_min_u_min
+export u_plus_d_plus, d_plus_u_plus
 export u_min_u_min, d_min_d_min
 export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
@@ -17,7 +18,7 @@ export S_plus_S_min, S_min_S_plus, S_exchange
 export nꜛ, nꜜ, nʰ, n
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
 export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
-export u⁻d⁻, d⁻u⁻
+export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
 export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
 export singlet⁻

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -634,8 +634,8 @@ function u_plus_u_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool
     return u_plus_u_plus(ComplexF64, P, S; slave_fermion)
 end
 function u_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
-                      spin_symmetry::Type{<:Sector};
-                      slave_fermion::Bool=false)
+                       spin_symmetry::Type{<:Sector};
+                       slave_fermion::Bool=false)
     return -copy(adjoint(u_min_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
 const u⁺u⁺ = u_plus_u_plus
@@ -690,8 +690,8 @@ function d_plus_d_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool
     return d_plus_d_plus(ComplexF64, P, S; slave_fermion)
 end
 function d_plus_d_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
-                      spin_symmetry::Type{<:Sector};
-                      slave_fermion::Bool=false)
+                       spin_symmetry::Type{<:Sector};
+                       slave_fermion::Bool=false)
     return -copy(adjoint(d_min_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
 const d⁺d⁺ = d_plus_d_plus

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -17,7 +17,8 @@ export S_plus_S_min, S_min_S_plus, S_exchange
 export nꜛ, nꜜ, nʰ, n
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
 export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
-export u⁻d⁻, d⁻u⁻, u⁻u⁻, d⁻d⁻
+export u⁻d⁻, d⁻u⁻
+export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
 export singlet⁻
 export S⁻S⁺, S⁺S⁻

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -625,6 +625,22 @@ end
 const u⁻u⁻ = u_min_u_min
 
 @doc """
+    u_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    u⁺u⁺(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that annihilates a spin-up particle at both sites.
+""" u_plus_u_plus
+function u_plus_u_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return u_plus_u_plus(ComplexF64, P, S; slave_fermion)
+end
+function u_plus_u_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector};
+                      slave_fermion::Bool=false)
+    return -copy(adjoint(u_min_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)))
+end
+const u⁺u⁺ = u_plus_u_plus
+
+@doc """
     d_min_d_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
     d⁻d⁻(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -12,7 +12,7 @@ export u_plus_d_plus, d_plus_u_plus
 export u_min_u_min, d_min_d_min
 export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
-export singlet_min
+export singlet_plus, singlet_min
 export S_plus_S_min, S_min_S_plus, S_exchange
 
 export nꜛ, nꜜ, nʰ, n
@@ -21,7 +21,7 @@ export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
 export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
 export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
-export singlet⁻
+export singlet⁺, singlet⁻
 export S⁻S⁺, S⁺S⁻
 
 """
@@ -786,19 +786,35 @@ end
 const e⁻e⁺ = e_min_e_plus
 
 @doc """
+    singlet_plus(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    singlet⁺(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+
+Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / sqrt(2)``,
+which creates the singlet state when acting on vaccum.
+""" singlet_plus
+function singlet_plus(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
+    return singlet_plus(ComplexF64, P, S; slave_fermion)
+end
+function singlet_plus(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+                      spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    return (u_plus_d_plus(elt, particle_symmetry, spin_symmetry; slave_fermion) -
+            d_plus_u_plus(elt, particle_symmetry, spin_symmetry; slave_fermion)) / sqrt(2)
+end
+const singlet⁺ = singlet_plus
+
+@doc """
     singlet_min(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
     singlet⁻(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
 
-Return the two-body singlet operator ``(e_{1,↓} e_{2,↑} - e_{1,↓} e_{2,↑}) / sqrt(2)``.
+Return the adjoint of `singlet_plus` operator, which is 
+``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / sqrt(2)``
 """ singlet_min
 function singlet_min(P::Type{<:Sector}, S::Type{<:Sector}; slave_fermion::Bool=false)
     return singlet_min(ComplexF64, P, S; slave_fermion)
 end
 function singlet_min(elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
-                     spin_symmetry::Type{<:Sector};
-                     slave_fermion::Bool=false)
-    return (u_min_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion) -
-            d_min_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)) / sqrt(2)
+                     spin_symmetry::Type{<:Sector}; slave_fermion::Bool=false)
+    return copy(adjoint(singlet_plus(elt, particle_symmetry, spin_symmetry; slave_fermion)))
 end
 const singlet⁻ = singlet_min
 

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -97,6 +97,7 @@ end
                 dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry)
                 updp = u_plus_d_plus(particle_symmetry, spin_symmetry)
                 dpup = d_plus_u_plus(particle_symmetry, spin_symmetry)
+
                 @test swap_2sites(umum) ≈ -umum
                 @test swap_2sites(dmdm) ≈ -dmdm
                 @test swap_2sites(upup) ≈ -upup

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -75,18 +75,27 @@ end
                       u_num(particle_symmetry, spin_symmetry)
             end
 
-            # test singlet operator
             if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
+                # test singlet operator
                 sing = singlet_min(particle_symmetry, spin_symmetry)
                 ud = u_min_d_min(particle_symmetry, spin_symmetry)
                 du = d_min_u_min(particle_symmetry, spin_symmetry)
                 @test swap_2sites(ud) ≈ -du
                 @test swap_2sites(sing) ≈ sing
                 @test sing ≈ (ud - du) / sqrt(2)
+                # test triplet operators
+                if spin_symmetry == Trivial
+                    uu = u_min_u_min(particle_symmetry, spin_symmetry)
+                    dd = d_min_d_min(particle_symmetry, spin_symmetry)
+                    @test swap_2sites(uu) ≈ -uu
+                    @test swap_2sites(dd) ≈ -dd
+                end
             else
                 @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)
             end
 
             # test spin operator

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -92,9 +92,9 @@ end
             # test triplet operators
             if particle_symmetry == Trivial && spin_symmetry == Trivial
                 uu = u_min_u_min(particle_symmetry, spin_symmetry)
-                    dd = d_min_d_min(particle_symmetry, spin_symmetry)
-                    @test swap_2sites(uu) ≈ -uu
-                    @test swap_2sites(dd) ≈ -dd
+                dd = d_min_d_min(particle_symmetry, spin_symmetry)
+                @test swap_2sites(uu) ≈ -uu
+                @test swap_2sites(dd) ≈ -dd
             else
                 @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -91,14 +91,17 @@ end
 
             # test triplet operators
             if particle_symmetry == Trivial && spin_symmetry == Trivial
-                uu = u_min_u_min(particle_symmetry, spin_symmetry)
-                dd = d_min_d_min(particle_symmetry, spin_symmetry)
+                umum = u_min_u_min(particle_symmetry, spin_symmetry)
+                dmdm = d_min_d_min(particle_symmetry, spin_symmetry)
                 upup = u_plus_u_plus(particle_symmetry, spin_symmetry)
                 dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry)
-                @test swap_2sites(uu) ≈ -uu
-                @test swap_2sites(dd) ≈ -dd
+                updp = u_plus_d_plus(particle_symmetry, spin_symmetry)
+                dpup = d_plus_u_plus(particle_symmetry, spin_symmetry)
+                @test swap_2sites(umum) ≈ -umum
+                @test swap_2sites(dmdm) ≈ -dmdm
                 @test swap_2sites(upup) ≈ -upup
                 @test swap_2sites(dpdp) ≈ -dpdp
+                @test swap_2sites(updp) ≈ -dpup
             else
                 @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -75,18 +75,23 @@ end
                       u_num(particle_symmetry, spin_symmetry)
             end
 
-            # test singlet operator
+            # test singlet operators
             if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
                 sing = singlet_min(particle_symmetry, spin_symmetry)
-                ud = u_min_d_min(particle_symmetry, spin_symmetry)
-                du = d_min_u_min(particle_symmetry, spin_symmetry)
-                @test swap_2sites(ud) ≈ -du
+                umdm = u_min_d_min(particle_symmetry, spin_symmetry)
+                dmum = d_min_u_min(particle_symmetry, spin_symmetry)
+                @test swap_2sites(umdm) ≈ -dmum
                 @test swap_2sites(sing) ≈ sing
-                @test sing ≈ (ud - du) / sqrt(2)
+                @test sing ≈ (umdm - dmum) / sqrt(2)
+                updp = u_plus_d_plus(particle_symmetry, spin_symmetry)
+                dpup = d_plus_u_plus(particle_symmetry, spin_symmetry)
+                @test swap_2sites(updp) ≈ -dpup
             else
                 @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError u_plus_d_plus(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError d_plus_u_plus(particle_symmetry, spin_symmetry)
             end
 
             # test triplet operators
@@ -95,14 +100,10 @@ end
                 dmdm = d_min_d_min(particle_symmetry, spin_symmetry)
                 upup = u_plus_u_plus(particle_symmetry, spin_symmetry)
                 dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry)
-                updp = u_plus_d_plus(particle_symmetry, spin_symmetry)
-                dpup = d_plus_u_plus(particle_symmetry, spin_symmetry)
-
                 @test swap_2sites(umum) ≈ -umum
                 @test swap_2sites(dmdm) ≈ -dmdm
                 @test swap_2sites(upup) ≈ -upup
                 @test swap_2sites(dpdp) ≈ -dpdp
-                @test swap_2sites(updp) ≈ -dpup
             else
                 @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -77,16 +77,17 @@ end
 
             # test singlet operators
             if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
-                sing = singlet_min(particle_symmetry, spin_symmetry)
+                singm = singlet_min(particle_symmetry, spin_symmetry)
                 umdm = u_min_d_min(particle_symmetry, spin_symmetry)
                 dmum = d_min_u_min(particle_symmetry, spin_symmetry)
                 @test swap_2sites(umdm) ≈ -dmum
-                @test swap_2sites(sing) ≈ sing
-                @test sing ≈ (umdm - dmum) / sqrt(2)
+                @test swap_2sites(singm) ≈ singm
+                @test singm ≈ (-umdm + dmum) / sqrt(2)
                 updp = u_plus_d_plus(particle_symmetry, spin_symmetry)
                 dpup = d_plus_u_plus(particle_symmetry, spin_symmetry)
                 @test swap_2sites(updp) ≈ -dpup
             else
+                @test_throws ArgumentError singlet_plus(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry)

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -93,11 +93,17 @@ end
             if particle_symmetry == Trivial && spin_symmetry == Trivial
                 uu = u_min_u_min(particle_symmetry, spin_symmetry)
                 dd = d_min_d_min(particle_symmetry, spin_symmetry)
+                upup = u_plus_u_plus(particle_symmetry, spin_symmetry)
+                dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry)
                 @test swap_2sites(uu) ≈ -uu
                 @test swap_2sites(dd) ≈ -dd
+                @test swap_2sites(upup) ≈ -upup
+                @test swap_2sites(dpdp) ≈ -dpdp
             else
                 @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError u_plus_u_plus(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError d_plus_d_plus(particle_symmetry, spin_symmetry)
             end
 
             # test spin operator

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -75,25 +75,27 @@ end
                       u_num(particle_symmetry, spin_symmetry)
             end
 
+            # test singlet operator
             if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
-                # test singlet operator
                 sing = singlet_min(particle_symmetry, spin_symmetry)
                 ud = u_min_d_min(particle_symmetry, spin_symmetry)
                 du = d_min_u_min(particle_symmetry, spin_symmetry)
                 @test swap_2sites(ud) ≈ -du
                 @test swap_2sites(sing) ≈ sing
                 @test sing ≈ (ud - du) / sqrt(2)
-                # test triplet operators
-                if spin_symmetry == Trivial
-                    uu = u_min_u_min(particle_symmetry, spin_symmetry)
-                    dd = d_min_d_min(particle_symmetry, spin_symmetry)
-                    @test swap_2sites(uu) ≈ -uu
-                    @test swap_2sites(dd) ≈ -dd
-                end
             else
                 @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry)
+            end
+
+            # test triplet operators
+            if particle_symmetry == Trivial && spin_symmetry == Trivial
+                uu = u_min_u_min(particle_symmetry, spin_symmetry)
+                    dd = d_min_d_min(particle_symmetry, spin_symmetry)
+                    @test swap_2sites(uu) ≈ -uu
+                    @test swap_2sites(dd) ≈ -dd
+            else
                 @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
                 @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)
             end

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -121,13 +121,21 @@ end
                 if particle_symmetry == Trivial && spin_symmetry == Trivial
                     uu = u_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
                     dd = d_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
+                    upup = u_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
+                    dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
                     @test swap_2sites(uu) ≈ -uu
                     @test swap_2sites(dd) ≈ -dd
+                    @test swap_2sites(upup) ≈ -upup
+                    @test swap_2sites(dpdp) ≈ -dpdp
                 else
                     @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
                     @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
+                    @test_throws ArgumentError u_plus_u_plus(particle_symmetry,
+                                                             spin_symmetry; slave_fermion)
+                    @test_throws ArgumentError d_plus_d_plus(particle_symmetry,
+                                                             spin_symmetry; slave_fermion)
                 end
 
                 # test spin operator

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -96,18 +96,21 @@ end
 
                 # test singlet operators
                 if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
-                    sing = singlet_min(particle_symmetry, spin_symmetry;
-                                       slave_fermion)
+                    singm = singlet_min(particle_symmetry, spin_symmetry;
+                                        slave_fermion)
                     umdm = u_min_d_min(particle_symmetry, spin_symmetry;
                                        slave_fermion)
                     dmum = d_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
                     @test swap_2sites(umdm) ≈ -dmum
-                    @test swap_2sites(sing) ≈ sing
-                    @test sing ≈ (umdm - dmum) / sqrt(2)
+                    @test swap_2sites(singm) ≈ singm
+                    @test singm ≈ (-umdm + dmum) / sqrt(2)
                     updp = u_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
                     dpup = d_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
                     @test swap_2sites(updp) ≈ -dpup
                 else
+                    @test_throws ArgumentError singlet_plus(particle_symmetry,
+                                                            spin_symmetry;
+                                                            slave_fermion)
                     @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
                     @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry;

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -94,8 +94,8 @@ end
                                                      slave_fermion)
                 end
 
+                # test singlet operator
                 if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
-                    # test singlet operator
                     sing = singlet_min(particle_symmetry, spin_symmetry;
                                        slave_fermion)
                     ud = u_min_d_min(particle_symmetry, spin_symmetry;
@@ -104,13 +104,6 @@ end
                     @test swap_2sites(ud) ≈ -du
                     @test swap_2sites(sing) ≈ sing
                     @test sing ≈ (ud - du) / sqrt(2)
-                    # test triplet operators
-                    if spin_symmetry == Trivial
-                        uu = u_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
-                        dd = d_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
-                        @test swap_2sites(uu) ≈ -uu
-                        @test swap_2sites(dd) ≈ -dd
-                    end
                 else
                     @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
@@ -118,6 +111,19 @@ end
                                                            slave_fermion)
                     @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
+                    @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry;
+                                                           slave_fermion)
+                    @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry;
+                                                           slave_fermion)
+                end
+
+                # test triplet operators
+                if particle_symmetry == Trivial && spin_symmetry == Trivial
+                    uu = u_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
+                    dd = d_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
+                    @test swap_2sites(uu) ≈ -uu
+                    @test swap_2sites(dd) ≈ -dd
+                else
                     @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
                     @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry;

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -119,14 +119,18 @@ end
 
                 # test triplet operators
                 if particle_symmetry == Trivial && spin_symmetry == Trivial
-                    uu = u_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
-                    dd = d_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
+                    umum = u_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
+                    dmdm = d_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
                     upup = u_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
                     dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                    @test swap_2sites(uu) ≈ -uu
-                    @test swap_2sites(dd) ≈ -dd
+                    updp = u_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
+                    dpup = d_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
+
+                    @test swap_2sites(umum) ≈ -umum
+                    @test swap_2sites(dmdm) ≈ -dmdm
                     @test swap_2sites(upup) ≈ -upup
                     @test swap_2sites(dpdp) ≈ -dpdp
+                    @test swap_2sites(updp) ≈ -dpup
                 else
                     @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -94,8 +94,8 @@ end
                                                      slave_fermion)
                 end
 
-                # test singlet operator
                 if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
+                    # test singlet operator
                     sing = singlet_min(particle_symmetry, spin_symmetry;
                                        slave_fermion)
                     ud = u_min_d_min(particle_symmetry, spin_symmetry;
@@ -104,12 +104,23 @@ end
                     @test swap_2sites(ud) ≈ -du
                     @test swap_2sites(sing) ≈ sing
                     @test sing ≈ (ud - du) / sqrt(2)
+                    # test triplet operators
+                    if spin_symmetry == Trivial
+                        uu = u_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
+                        dd = d_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
+                        @test swap_2sites(uu) ≈ -uu
+                        @test swap_2sites(dd) ≈ -dd
+                    end
                 else
                     @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
                     @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
                     @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry;
+                                                           slave_fermion)
+                    @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry;
+                                                           slave_fermion)
+                    @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
                 end
 

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -94,16 +94,19 @@ end
                                                      slave_fermion)
                 end
 
-                # test singlet operator
+                # test singlet operators
                 if particle_symmetry == Trivial && spin_symmetry !== SU2Irrep
                     sing = singlet_min(particle_symmetry, spin_symmetry;
                                        slave_fermion)
-                    ud = u_min_d_min(particle_symmetry, spin_symmetry;
-                                     slave_fermion)
-                    du = d_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
-                    @test swap_2sites(ud) ≈ -du
+                    umdm = u_min_d_min(particle_symmetry, spin_symmetry;
+                                       slave_fermion)
+                    dmum = d_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
+                    @test swap_2sites(umdm) ≈ -dmum
                     @test swap_2sites(sing) ≈ sing
-                    @test sing ≈ (ud - du) / sqrt(2)
+                    @test sing ≈ (umdm - dmum) / sqrt(2)
+                    updp = u_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
+                    dpup = d_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
+                    @test swap_2sites(updp) ≈ -dpup
                 else
                     @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
@@ -111,10 +114,12 @@ end
                                                            slave_fermion)
                     @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)
-                    @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry;
-                                                           slave_fermion)
-                    @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry;
-                                                           slave_fermion)
+                    @test_throws ArgumentError u_plus_d_plus(particle_symmetry,
+                                                             spin_symmetry;
+                                                             slave_fermion)
+                    @test_throws ArgumentError d_plus_u_plus(particle_symmetry,
+                                                             spin_symmetry;
+                                                             slave_fermion)
                 end
 
                 # test triplet operators
@@ -123,14 +128,10 @@ end
                     dmdm = d_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
                     upup = u_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
                     dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                    updp = u_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
-                    dpup = d_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
-
                     @test swap_2sites(umum) ≈ -umum
                     @test swap_2sites(dmdm) ≈ -dmdm
                     @test swap_2sites(upup) ≈ -upup
                     @test swap_2sites(dpdp) ≈ -dpdp
-                    @test swap_2sites(updp) ≈ -dpup
                 else
                     @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry;
                                                            slave_fermion)


### PR DESCRIPTION
This PR adds the triplet pairing operators $c_{i\uparrow} c_{j\uparrow}, c_{i\downarrow} c_{j\downarrow}$ to `TJOperators` and `HubbardOperators`, which are only defined for `Trivial` particle and spin symmetry. 

When acting on the vacuum state, they create the triplet state $| \uparrow \uparrow \rangle$ (with $s_z = +1$), $| \downarrow \downarrow \rangle$ (with $s_z = -1$). The $s_z = 0$ state $| \uparrow \downarrow \rangle + | \downarrow \uparrow \rangle$ is already covered by `u_min_d_min` and `d_min_u_min`. 

EDIT: In addition, the definition of `singlet_min` is changed to the negative of the original. It is now defined as `adjoint(singlet_plus)`, where
```
singlet_plus = (u_plus_d_plus - d_plus_u_plus) / sqrt(2).
```