### PR TITLE
Fix `hubbard_space` for `SU2Irrep, U1Irrep` and add tests

### DIFF
--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -57,7 +57,8 @@ function hubbard_space(::Type{SU2Irrep}, ::Type{Trivial})
     return Vect[FermionParity ⊠ SU2Irrep]((0, 0) => 2, (1, 1 // 2) => 1)
 end
 function hubbard_space(::Type{SU2Irrep}, ::Type{U1Irrep})
-    return Vect[FermionParity ⊠ SU2Irrep ⊠ U1Irrep]((0, 0, 0) => 1, (1, 1 // 2, 1) => 1)
+    return Vect[FermionParity ⊠ SU2Irrep ⊠ U1Irrep]((0, 0, 0) => 1, (1, 1 // 2, 1) => 1,
+                                                    (0, 0, 2) => 1)
 end
 function hubbard_space(::Type{SU2Irrep}, ::Type{SU2Irrep})
     return Vect[FermionParity ⊠ SU2Irrep ⊠ SU2Irrep]((1, 1 // 2, 1 // 2) => 1)

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -44,6 +44,9 @@ end
     for particle_symmetry in (Trivial, U1Irrep, SU2Irrep),
         spin_symmetry in (Trivial, U1Irrep, SU2Irrep)
 
+        space = hubbard_space(particle_symmetry, spin_symmetry)
+        @test dim(space) == 4
+
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             # test hopping operator
             epem = e_plus_e_min(particle_symmetry, spin_symmetry)


### PR DESCRIPTION
Correct the `hubbard_space` function for `SU2Irrep` and `U1Irrep` by adding a new mapping. Include tests to verify the dimensionality of the generated space.

Fixes #22