### PR TITLE
Change `f_min_f_min` convention

### DIFF
--- a/src/fermionoperators.jl
+++ b/src/fermionoperators.jl
@@ -95,7 +95,7 @@ Return the two-body operator that annihilates a particle at the first and at the
 function f_min_f_min(T::Type{<:Number} = ComplexF64)
     t = two_site_operator(T)
     I = sectortype(t)
-    t[(I(0), I(0), dual(I(1)), dual(I(1)))] .= 1
+    t[(I(0), I(0), dual(I(1)), dual(I(1)))] .= -1
     return t
 end
 const f⁻f⁻ = f_min_f_min

--- a/test/fermionoperators.jl
+++ b/test/fermionoperators.jl
@@ -19,7 +19,7 @@ using StableRNGs
     # @test ff⁺ ≈ -swap_2sites(f⁺f)
 
     @test f⁻f⁺()' ≈ -f⁺f⁻()
-    @test f⁻f⁻()' ≈ f⁺f⁺()
+    @test f⁻f⁻()' ≈ -f⁺f⁺()
     @test (f⁺f⁻() - f⁻f⁺())' ≈ f⁺f⁻() - f⁻f⁺()
     @test (f⁺f⁻() + f⁻f⁺())' ≈ -(f⁻f⁺() + f⁺f⁻())
 


### PR DESCRIPTION
Previously, `f_min_f_min` was defined to be the same as `adjoint(f_plus_f_plus)`, i.e. it is $(f^\dagger_1 f^\dagger_2)^\dagger = f_2 f_1$. Now I change it to $f_1 f_2$ (the negative of the original), which is the convention we use for other 2-body operators. 