### PR TITLE
Singlet pair NN-hopping (3-site) and correlation (4-site) in Hubbard and t-J models

### DIFF
--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -14,8 +14,7 @@ export u_min_u_min, d_min_d_min
 export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
 export singlet_plus, singlet_min
-export singlet_plus_singlet_min_3site
-export singlet_plus_singlet_min_4site
+export singlet_plus_singlet_min_3site, singlet_plus_singlet_min_4site
 export S_plus_S_min, S_min_S_plus, S_exchange
 
 export n, nꜛ, nꜜ, nꜛꜜ, nʰ
@@ -24,7 +23,8 @@ export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
 export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
 export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
-export singlet⁺, singlet⁻, Δ⁺ij_Δjk, Δ⁺ij_Δkl
+export singlet⁺, singlet⁻
+export Δ⁺ij_Δjk, Δ⁺ij_Δkl
 export S⁻S⁺, S⁺S⁻, SS
 
 """

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -14,6 +14,8 @@ export u_min_u_min, d_min_d_min
 export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
 export singlet_plus, singlet_min
+export singlet_plus_singlet_min_3site
+export singlet_plus_singlet_min_4site
 export S_plus_S_min, S_min_S_plus, S_exchange
 
 export n, nꜛ, nꜜ, nꜛꜜ, nʰ
@@ -571,6 +573,45 @@ end
 const singlet⁻ = singlet_min
 
 @doc """
+    singlet_plus_singlet_min_3site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+
+Returns the 3-site term ``O_{ijk} = A^†_{ij} A_{jk}``, where
+``A^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
+It describes the hopping of a singlet pair from bond `(j,k)`
+to a nearest neighbor bond `(i,j)` sharing site `j`.
+""" singlet_plus_singlet_min_3site
+function singlet_plus_singlet_min_3site(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    #=
+                -5      -6
+            ┌---┴-------┴---┐
+            |     A_{jk}    |
+            └---┬-------┬---┘
+        -4      1       -3
+    ┌---┴-------┴---┐
+    |    A†_{ij}    |
+    └---┬-------┬---┘
+        -1      -2
+        i       j       k
+    =#
+    singp = singlet_plus(elt, Trivial, Trivial)
+    singm = singp'
+    return @tensor t[-1 -2 -3; -4 -5 -6] := singp[-1 -2; -4 1] * singm[1 -3; -5 -6]
+end
+
+
+@doc """
+    singlet_plus_singlet_min_4site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+
+Returns the 4-site term ``O_{ijkl} = A^†_{ij} A_{kl}``, where
+``A^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
+It measures the singlet pair correlation between two bonds `(i,j)` and `(k,l)`.
+""" singlet_plus_singlet_min_4site
+function singlet_plus_singlet_min_4site(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    singp = singlet_plus(elt, Trivial, Trivial)
+    return singp ⊗ singp'
+end
+
+@doc """
     S_plus_S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     S⁺S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
@@ -622,6 +663,7 @@ for opname in (
         :u_min_u_min, :d_min_d_min, :u_plus_u_plus, :d_plus_d_plus,
         :e_plus_e_min, :e_min_e_plus, :e_hopping,
         :singlet_plus, :singlet_min,
+        :singlet_plus_singlet_min_3site, :singlet_plus_singlet_min_4site,
         :S_plus_S_min, :S_min_S_plus, :S_exchange,
     )
     @eval begin

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -24,7 +24,7 @@ export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
 export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
 export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
-export singlet⁺, singlet⁻
+export singlet⁺, singlet⁻, Δ⁺ij_Δjk, Δ⁺ij_Δkl
 export S⁻S⁺, S⁺S⁻, SS
 
 """
@@ -547,6 +547,45 @@ Return the adjoint of `singlet_plus` operator, which is
 """
 @operator singlet⁻ function singlet_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return copy(adjoint(singlet_plus(elt, Trivial, Trivial)))
+end
+
+"""
+    singlet_plus_singlet_min_3site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+
+Returns the 3-site term ``O_{ijk} = Δ^†_{ij} Δ_{jk}``, where
+``Δ^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
+It describes the hopping of a singlet pair from bond `(j,k)`
+to a nearest neighbor bond `(i,j)` sharing site `j`.
+"""
+@operator Δ⁺ij_Δjk function singlet_plus_singlet_min_3site(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    #=
+                -5      -6
+            ┌---┴-------┴---┐
+            |     A_{jk}    |
+            └---┬-------┬---┘
+        -4      1       -3
+    ┌---┴-------┴---┐
+    |    A†_{ij}    |
+    └---┬-------┬---┘
+        -1      -2
+        i       j       k
+    =#
+    singp = singlet_plus(elt, Trivial, Trivial)
+    singm = singp'
+    return @tensor t[-1 -2 -3; -4 -5 -6] := singp[-1 -2; -4 1] * singm[1 -3; -5 -6]
+end
+
+
+"""
+    singlet_plus_singlet_min_4site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+
+Returns the 4-site term ``O_{ijkl} = Δ^†_{ij} Δ_{kl}``, where
+``Δ^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
+It measures the singlet pair correlation between two bonds `(i,j)` and `(k,l)`.
+"""
+@operator Δ⁺ij_Δkl function singlet_plus_singlet_min_4site(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+    singp = singlet_plus(elt, Trivial, Trivial)
+    return singp ⊗ singp'
 end
 
 """

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -17,6 +17,7 @@ export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
 export singlet_plus, singlet_min
 export S_plus_S_min, S_min_S_plus, S_exchange
+export threesite
 
 export nꜛ, nꜜ, nʰ, n
 export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
@@ -169,6 +170,70 @@ for (opname, alias) in zip(
     isnothing(alias) || @eval begin
         const $alias = $opname
     end
+end
+
+"""
+The 3-site term `c†_{i↑} c†_{j↓} c_{j↓} c_{k↑}`.
+"""
+function u_plus_d_num_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion = false)
+    hop_up = u_plus_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
+    Nd = d_num(elt, particle_symmetry, spin_symmetry; slave_fermion)
+    return permute(hop_up ⊗ Nd, ((1, 3, 2), (4, 6, 5)))
+end
+"""
+The 3-site term `c†_{i↓} c†_{j↑} c_{j↑} c_{k↓}`.
+"""
+function d_plus_u_num_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion = false)
+    hop_down = d_plus_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
+    Nu = u_num(elt, particle_symmetry, spin_symmetry; slave_fermion)
+    return permute(hop_down ⊗ Nu, ((1, 3, 2), (4, 6, 5)))
+end
+
+#= 
+        -4         -5
+    ┌---┴-----------┴---┐
+    |   c†_{i↑} c_{j↑}  |
+    └---┬-----------┬---┘
+        -1          1           -6
+                ┌---┴-----------┴---┐
+                |   c†_{j↓} c_{k↓}  |
+                └---┬-----------┬---┘
+                    -2         -3
+=#
+"""
+The 3-site term `c†_{j↓} c_{k↓} c†_{i↑} c_{j↑}`.
+"""
+function Cpu_CpdCmu_Cmd(elt, particle_symmetry, spin_symmetry; slave_fermion = false)
+    hop_up = u_plus_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
+    hop_down = d_plus_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
+    @tensor op[-1 -2 -3; -4 -5 -6] := hop_down[-2 -3; 1 -6] * hop_up[-1 1; -4 -5]
+    return op
+end
+"""
+The 3-site term `c†_{j↑} c_{k↑} c†_{i↓} c_{j↓}`.
+"""
+function Cpd_CpuCmd_Cmu(elt, particle_symmetry, spin_symmetry; slave_fermion = false)
+    hop_up = u_plus_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
+    hop_down = d_plus_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion)
+    @tensor op[-1 -2 -3; -4 -5 -6] := hop_up[-2 -3; 1 -6] * hop_down[-1 1; -4 -5]
+    return op
+end
+
+"""
+    threesite( elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+
+The 3-site term in t-J model ``O_{ijk} = \\sum_σ O_{ijk,σ}``, where
+```
+    O_{ijk,σ} = c†_{iσ} c†_{jσ̄} c_{jσ̄} c_{kσ} + c†_{jσ̄} c_{kσ̄} c†_{iσ} c_{jσ}
+```
+where `i`, `k` are nearest neighbors of `j`. Note that ``O_{kji} = O^†_{ijk}``.
+(Reference: )
+"""
+function threesite(elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    return u_plus_d_num_u_min(elt, particle_symmetry, spin_symmetry; slave_fermion) +
+        d_plus_u_num_d_min(elt, particle_symmetry, spin_symmetry; slave_fermion) +
+        Cpu_CpdCmu_Cmd(elt, particle_symmetry, spin_symmetry; slave_fermion) +
+        Cpd_CpuCmd_Cmu(elt, particle_symmetry, spin_symmetry; slave_fermion)
 end
 
 slave_fermion_auxiliary_charge(::Type{FermionParity}) = FermionParity(1)

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -16,6 +16,7 @@ export u_min_u_min, d_min_d_min
 export u_plus_u_plus, d_plus_d_plus
 export e_plus_e_min, e_min_e_plus, e_hopping
 export singlet_plus, singlet_min
+export singlet_plus_singlet_min_3site, singlet_plus_singlet_min_4site
 export S_plus_S_min, S_min_S_plus, S_exchange
 
 export nꜛ, nꜜ, nʰ, n
@@ -25,6 +26,7 @@ export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
 export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
 export singlet⁺, singlet⁻
+export Δ⁺ij_Δjk, Δ⁺ij_Δkl
 export S⁻S⁺, S⁺S⁻, SS
 
 export transform_slave_fermion
@@ -112,6 +114,7 @@ for (opname, alias) in zip(
             :u_min_u_min, :d_min_d_min, :u_plus_u_plus, :d_plus_d_plus,
             :e_plus_e_min, :e_min_e_plus, :e_hopping,
             :singlet_plus, :singlet_min,
+            :singlet_plus_singlet_min_3site, :singlet_plus_singlet_min_4site,
             :S_plus_S_min, :S_min_S_plus, :S_exchange,
         ), (
             :n, :nꜛ, :nꜜ, :nʰ,
@@ -121,6 +124,7 @@ for (opname, alias) in zip(
             :u⁻u⁻, :u⁺u⁺, :d⁻d⁻, :d⁺d⁺,
             :e⁺e⁻, :e⁻e⁺, :e_hop,
             :singlet⁺, :singlet⁻,
+            :Δ⁺ij_Δjk, :Δ⁺ij_Δkl,
             :S⁻S⁺, :S⁺S⁻, :SS,
         )
     )

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -12,7 +12,7 @@ spin_syms = (Trivial, U1Irrep, SU2Irrep)
 
 # operator availability, as determined by the symmetries each operator breaks:
 # - u_num, d_num, S_z and the u/d hopping pairs break SU2 spin symmetry
-# - e_num, ud_num, h_num and e_plus_e_min/e_min_e_plus break SU2 particle symmetry
+# - e_num, ud_num, h_num, e_plus_e_min/e_min_e_plus and singlet_plus_singlet_min_3/4site break SU2 particle symmetry
 # - the pair (charge non-conserving) operators break U1 and SU2 particle symmetry
 # - half_ud_num, e_hopping, S_exchange are compatible with all symmetries
 has_u_num(P, S) = P !== SU2Irrep && S !== SU2Irrep
@@ -22,6 +22,7 @@ has_S_z(P, S) = S !== SU2Irrep
 has_e_pm(P, S) = P !== SU2Irrep
 has_pair(P, S) = P === Trivial && S !== SU2Irrep
 has_singlet(P, S) = P === Trivial
+has_paircor(P, S) = P !== SU2Irrep
 has_triplet(P, S) = P === Trivial && S === Trivial
 
 @testset "basis transformations" begin
@@ -82,6 +83,7 @@ end
                 (has_u_num(particle_symmetry, spin_symmetry), (u_num, d_num)),
                 (has_e_pm(particle_symmetry, spin_symmetry), (e_plus_e_min,)),
                 (has_singlet(particle_symmetry, spin_symmetry), (singlet_plus,)),
+                (has_paircor(partialsort, spin_symmetry), (singlet_plus_singlet_min_3site, singlet_plus_singlet_min_4site)),
                 (has_S_z(particle_symmetry, spin_symmetry), (S_plus_S_min, S_min_S_plus)),
             )
             for f in fs

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -94,7 +94,7 @@ end
                 (has_u_num(particle_symmetry, spin_symmetry), (u_num, d_num)),
                 (has_e_pm(particle_symmetry, spin_symmetry), (e_plus_e_min,)),
                 (has_singlet(particle_symmetry, spin_symmetry), (singlet_plus,)),
-                (has_paircor(particle_symmetry, spin_symmetry), (singlet_plus_singlet_min_3site, singlet_plus_singlet_min_4site)),
+                (has_paircor(particle_symmetry, spin_symmetry), (Δ⁺ij_Δjk, Δ⁺ij_Δkl)),
                 (has_S_z(particle_symmetry, spin_symmetry), (S_plus_S_min, S_min_S_plus)),
             )
             for f in fs
@@ -112,211 +112,211 @@ end
     end
 end
 
-@testset "regression values" begin
-    # staggered-gauge e_hopping with SU2 x SU2 symmetry
-    t = e_hopping(ComplexF64, SU2Irrep, SU2Irrep)
-    @test_throws ArgumentError e_hopping(Float64, SU2Irrep, SU2Irrep)
-    I2 = sectortype(t)
-    even = I2(0, 1 // 2, 0)
-    odd = I2(1, 0, 1 // 2)
-    f1 = only(fusiontrees((odd, odd), one(I2)))
-    f2 = only(fusiontrees((even, even), one(I2)))
-    f3 = only(fusiontrees((even, odd), I2((1, 1 // 2, 1 // 2))))
-    f4 = only(fusiontrees((odd, even), I2((1, 1 // 2, 1 // 2))))
-    @test all(t[f1, f2] .≈ 2im) && all(t[f2, f1] .≈ -2im)
-    @test all(t[f3, f4] .≈ im) && all(t[f4, f3] .≈ -im)
+# @testset "regression values" begin
+#     # staggered-gauge e_hopping with SU2 x SU2 symmetry
+#     t = e_hopping(ComplexF64, SU2Irrep, SU2Irrep)
+#     @test_throws ArgumentError e_hopping(Float64, SU2Irrep, SU2Irrep)
+#     I2 = sectortype(t)
+#     even = I2(0, 1 // 2, 0)
+#     odd = I2(1, 0, 1 // 2)
+#     f1 = only(fusiontrees((odd, odd), one(I2)))
+#     f2 = only(fusiontrees((even, even), one(I2)))
+#     f3 = only(fusiontrees((even, odd), I2((1, 1 // 2, 1 // 2))))
+#     f4 = only(fusiontrees((odd, even), I2((1, 1 // 2, 1 // 2))))
+#     @test all(t[f1, f2] .≈ 2im) && all(t[f2, f1] .≈ -2im)
+#     @test all(t[f3, f4] .≈ im) && all(t[f4, f3] .≈ -im)
 
-    # e_plus_e_min moves a particle from the second site to the first:
-    # ⟨↑,0|e⁺e⁻|0,↑⟩ = 1 while ⟨0,↑|e⁺e⁻|↑,0⟩ = 0, in every symmetric version
-    # (regression check: the hand-written SU2-spin versions used to be transposed)
-    for (P, S) in Iterators.product(particle_syms, spin_syms)
-        has_e_pm(P, S) || continue
-        A = convert(Array, e_plus_e_min(ComplexF64, P, S))
-        U = convert(Array, basis_transform(P, S))
-        i0 = findfirst(==(1), U[:, 1]) # dense index of |0⟩
-        iu = findfirst(==(1), U[:, 3]) # dense index of |↑⟩
-        @test A[iu, i0, i0, iu] ≈ 1
-        @test abs(A[i0, iu, iu, i0]) < 1.0e-12
-    end
-end
+#     # e_plus_e_min moves a particle from the second site to the first:
+#     # ⟨↑,0|e⁺e⁻|0,↑⟩ = 1 while ⟨0,↑|e⁺e⁻|↑,0⟩ = 0, in every symmetric version
+#     # (regression check: the hand-written SU2-spin versions used to be transposed)
+#     for (P, S) in Iterators.product(particle_syms, spin_syms)
+#         has_e_pm(P, S) || continue
+#         A = convert(Array, e_plus_e_min(ComplexF64, P, S))
+#         U = convert(Array, basis_transform(P, S))
+#         i0 = findfirst(==(1), U[:, 1]) # dense index of |0⟩
+#         iu = findfirst(==(1), U[:, 3]) # dense index of |↑⟩
+#         @test A[iu, i0, i0, iu] ≈ 1
+#         @test abs(A[i0, iu, iu, i0]) < 1.0e-12
+#     end
+# end
 
-@testset "basic properties" begin
-    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
-        # test hopping operator
-        if has_e_pm(particle_symmetry, spin_symmetry)
-            epem = e_plus_e_min(particle_symmetry, spin_symmetry)
-            emep = e_min_e_plus(particle_symmetry, spin_symmetry)
-            @test epem' ≈ -emep ≈ swap_2sites(epem)
-        else
-            @test_throws ArgumentError e_plus_e_min(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError e_min_e_plus(particle_symmetry, spin_symmetry)
-        end
-        ehop = e_hopping(particle_symmetry, spin_symmetry)
-        @test ehop' ≈ ehop
+# @testset "basic properties" begin
+#     for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+#         # test hopping operator
+#         if has_e_pm(particle_symmetry, spin_symmetry)
+#             epem = e_plus_e_min(particle_symmetry, spin_symmetry)
+#             emep = e_min_e_plus(particle_symmetry, spin_symmetry)
+#             @test epem' ≈ -emep ≈ swap_2sites(epem)
+#         else
+#             @test_throws ArgumentError e_plus_e_min(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError e_min_e_plus(particle_symmetry, spin_symmetry)
+#         end
+#         ehop = e_hopping(particle_symmetry, spin_symmetry)
+#         @test ehop' ≈ ehop
 
-        if has_u_num(particle_symmetry, spin_symmetry)
-            dpdm = d_plus_d_min(particle_symmetry, spin_symmetry)
-            dmdp = d_min_d_plus(particle_symmetry, spin_symmetry)
-            @test dpdm' ≈ -dmdp ≈ swap_2sites(dpdm)
-            upum = u_plus_u_min(particle_symmetry, spin_symmetry)
-            umup = u_min_u_plus(particle_symmetry, spin_symmetry)
-            @test upum' ≈ -umup ≈ swap_2sites(upum)
-        else
-            @test_throws ArgumentError u_plus_u_min(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError u_min_u_plus(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError d_plus_d_min(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError d_min_d_plus(particle_symmetry, spin_symmetry)
-        end
+#         if has_u_num(particle_symmetry, spin_symmetry)
+#             dpdm = d_plus_d_min(particle_symmetry, spin_symmetry)
+#             dmdp = d_min_d_plus(particle_symmetry, spin_symmetry)
+#             @test dpdm' ≈ -dmdp ≈ swap_2sites(dpdm)
+#             upum = u_plus_u_min(particle_symmetry, spin_symmetry)
+#             umup = u_min_u_plus(particle_symmetry, spin_symmetry)
+#             @test upum' ≈ -umup ≈ swap_2sites(upum)
+#         else
+#             @test_throws ArgumentError u_plus_u_min(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError u_min_u_plus(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError d_plus_d_min(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError d_min_d_plus(particle_symmetry, spin_symmetry)
+#         end
 
-        # test number operator
-        if has_u_num(particle_symmetry, spin_symmetry)
-            @test e_num(particle_symmetry, spin_symmetry) ≈
-                u_num(particle_symmetry, spin_symmetry) +
-                d_num(particle_symmetry, spin_symmetry)
-            @test ud_num(particle_symmetry, spin_symmetry) ≈
-                u_num(particle_symmetry, spin_symmetry) *
-                d_num(particle_symmetry, spin_symmetry) ≈
-                d_num(particle_symmetry, spin_symmetry) *
-                u_num(particle_symmetry, spin_symmetry)
-        end
-        if has_e_num(particle_symmetry, spin_symmetry)
-            @test half_ud_num(particle_symmetry, spin_symmetry) ≈
-                ud_num(particle_symmetry, spin_symmetry) -
-                e_num(particle_symmetry, spin_symmetry) / 2 +
-                id(hubbard_space(particle_symmetry, spin_symmetry)) / 4
-        else
-            @test_throws ArgumentError e_num(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError ud_num(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError h_num(particle_symmetry, spin_symmetry)
-        end
+#         # test number operator
+#         if has_u_num(particle_symmetry, spin_symmetry)
+#             @test e_num(particle_symmetry, spin_symmetry) ≈
+#                 u_num(particle_symmetry, spin_symmetry) +
+#                 d_num(particle_symmetry, spin_symmetry)
+#             @test ud_num(particle_symmetry, spin_symmetry) ≈
+#                 u_num(particle_symmetry, spin_symmetry) *
+#                 d_num(particle_symmetry, spin_symmetry) ≈
+#                 d_num(particle_symmetry, spin_symmetry) *
+#                 u_num(particle_symmetry, spin_symmetry)
+#         end
+#         if has_e_num(particle_symmetry, spin_symmetry)
+#             @test half_ud_num(particle_symmetry, spin_symmetry) ≈
+#                 ud_num(particle_symmetry, spin_symmetry) -
+#                 e_num(particle_symmetry, spin_symmetry) / 2 +
+#                 id(hubbard_space(particle_symmetry, spin_symmetry)) / 4
+#         else
+#             @test_throws ArgumentError e_num(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError ud_num(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError h_num(particle_symmetry, spin_symmetry)
+#         end
 
-        # test singlet operators
-        if has_pair(particle_symmetry, spin_symmetry)
-            singm = singlet_min(particle_symmetry, spin_symmetry)
-            umdm = u_min_d_min(particle_symmetry, spin_symmetry)
-            dmum = d_min_u_min(particle_symmetry, spin_symmetry)
-            @test swap_2sites(umdm) ≈ -dmum
-            @test swap_2sites(singm) ≈ singm
-            @test singm ≈ (-umdm + dmum) / sqrt(2)
-            updp = u_plus_d_plus(particle_symmetry, spin_symmetry)
-            dpup = d_plus_u_plus(particle_symmetry, spin_symmetry)
-            @test swap_2sites(updp) ≈ -dpup
-        elseif has_singlet(particle_symmetry, spin_symmetry)
-            singm = singlet_min(particle_symmetry, spin_symmetry)
-            @test swap_2sites(singm) ≈ singm
-        else
-            @test_throws ArgumentError singlet_plus(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError u_plus_d_plus(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError d_plus_u_plus(particle_symmetry, spin_symmetry)
-        end
+#         # test singlet operators
+#         if has_pair(particle_symmetry, spin_symmetry)
+#             singm = singlet_min(particle_symmetry, spin_symmetry)
+#             umdm = u_min_d_min(particle_symmetry, spin_symmetry)
+#             dmum = d_min_u_min(particle_symmetry, spin_symmetry)
+#             @test swap_2sites(umdm) ≈ -dmum
+#             @test swap_2sites(singm) ≈ singm
+#             @test singm ≈ (-umdm + dmum) / sqrt(2)
+#             updp = u_plus_d_plus(particle_symmetry, spin_symmetry)
+#             dpup = d_plus_u_plus(particle_symmetry, spin_symmetry)
+#             @test swap_2sites(updp) ≈ -dpup
+#         elseif has_singlet(particle_symmetry, spin_symmetry)
+#             singm = singlet_min(particle_symmetry, spin_symmetry)
+#             @test swap_2sites(singm) ≈ singm
+#         else
+#             @test_throws ArgumentError singlet_plus(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError u_plus_d_plus(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError d_plus_u_plus(particle_symmetry, spin_symmetry)
+#         end
 
-        # test triplet operators
-        if has_triplet(particle_symmetry, spin_symmetry)
-            umum = u_min_u_min(particle_symmetry, spin_symmetry)
-            dmdm = d_min_d_min(particle_symmetry, spin_symmetry)
-            upup = u_plus_u_plus(particle_symmetry, spin_symmetry)
-            dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry)
-            @test swap_2sites(umum) ≈ -umum
-            @test swap_2sites(dmdm) ≈ -dmdm
-            @test swap_2sites(upup) ≈ -upup
-            @test swap_2sites(dpdp) ≈ -dpdp
-        else
-            @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError u_plus_u_plus(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError d_plus_d_plus(particle_symmetry, spin_symmetry)
-        end
+#         # test triplet operators
+#         if has_triplet(particle_symmetry, spin_symmetry)
+#             umum = u_min_u_min(particle_symmetry, spin_symmetry)
+#             dmdm = d_min_d_min(particle_symmetry, spin_symmetry)
+#             upup = u_plus_u_plus(particle_symmetry, spin_symmetry)
+#             dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry)
+#             @test swap_2sites(umum) ≈ -umum
+#             @test swap_2sites(dmdm) ≈ -dmdm
+#             @test swap_2sites(upup) ≈ -upup
+#             @test swap_2sites(dpdp) ≈ -dpdp
+#         else
+#             @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError u_plus_u_plus(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError d_plus_d_plus(particle_symmetry, spin_symmetry)
+#         end
 
-        # test spin operator
-        if has_spin_ops(particle_symmetry, spin_symmetry)
-            test_spin_algebra(
-                S_x(particle_symmetry, spin_symmetry),
-                S_y(particle_symmetry, spin_symmetry),
-                S_z(particle_symmetry, spin_symmetry),
-            )
-            # test S_plus and S_min
-            @test S_plus_S_min(particle_symmetry, spin_symmetry) ≈
-                S_plus(particle_symmetry, spin_symmetry) ⊗
-                S_min(particle_symmetry, spin_symmetry)
-            @test S_min_S_plus(particle_symmetry, spin_symmetry) ≈
-                S_min(particle_symmetry, spin_symmetry) ⊗
-                S_plus(particle_symmetry, spin_symmetry)
-        else
-            @test_throws ArgumentError S_plus(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError S_min(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError S_x(particle_symmetry, spin_symmetry)
-            @test_throws ArgumentError S_y(particle_symmetry, spin_symmetry)
-            if !has_S_z(particle_symmetry, spin_symmetry)
-                @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry)
-            end
-        end
-    end
-end
+#         # test spin operator
+#         if has_spin_ops(particle_symmetry, spin_symmetry)
+#             test_spin_algebra(
+#                 S_x(particle_symmetry, spin_symmetry),
+#                 S_y(particle_symmetry, spin_symmetry),
+#                 S_z(particle_symmetry, spin_symmetry),
+#             )
+#             # test S_plus and S_min
+#             @test S_plus_S_min(particle_symmetry, spin_symmetry) ≈
+#                 S_plus(particle_symmetry, spin_symmetry) ⊗
+#                 S_min(particle_symmetry, spin_symmetry)
+#             @test S_min_S_plus(particle_symmetry, spin_symmetry) ≈
+#                 S_min(particle_symmetry, spin_symmetry) ⊗
+#                 S_plus(particle_symmetry, spin_symmetry)
+#         else
+#             @test_throws ArgumentError S_plus(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError S_min(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError S_x(particle_symmetry, spin_symmetry)
+#             @test_throws ArgumentError S_y(particle_symmetry, spin_symmetry)
+#             if !has_S_z(particle_symmetry, spin_symmetry)
+#                 @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry)
+#             end
+#         end
+#     end
+# end
 
-function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu)
-    @assert length(t) + 1 == length(U) == length(mu)
-    hopping = e_hopping(particle_symmetry, spin_symmetry)
-    interaction = ud_num(particle_symmetry, spin_symmetry)
-    chemical_potential = e_num(particle_symmetry, spin_symmetry)
-    H = operator_sum(hopping, -t) +
-        operator_sum(interaction, U) +
-        operator_sum(chemical_potential, -mu)
+# function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu)
+#     @assert length(t) + 1 == length(U) == length(mu)
+#     hopping = e_hopping(particle_symmetry, spin_symmetry)
+#     interaction = ud_num(particle_symmetry, spin_symmetry)
+#     chemical_potential = e_num(particle_symmetry, spin_symmetry)
+#     H = operator_sum(hopping, -t) +
+#         operator_sum(interaction, U) +
+#         operator_sum(chemical_potential, -mu)
 
-    return H
-end
-# particle-hole symmetric Hamiltonian (mu = U/2), compatible with all symmetries
-function hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
-    @assert length(t) + 1 == length(U)
-    hopping = e_hopping(particle_symmetry, spin_symmetry)
-    interaction = half_ud_num(particle_symmetry, spin_symmetry)
-    H = operator_sum(hopping, -t) +
-        operator_sum(interaction, U)
-    return H
-end
+#     return H
+# end
+# # particle-hole symmetric Hamiltonian (mu = U/2), compatible with all symmetries
+# function hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
+#     @assert length(t) + 1 == length(U)
+#     hopping = e_hopping(particle_symmetry, spin_symmetry)
+#     interaction = half_ud_num(particle_symmetry, spin_symmetry)
+#     H = operator_sum(hopping, -t) +
+#         operator_sum(interaction, U)
+#     return H
+# end
 
-@testset "spectrum" begin
-    rng = StableRNG(123)
-    L = 4
-    t = randn(rng, L - 1)
-    U = randn(rng, L)
+# @testset "spectrum" begin
+#     rng = StableRNG(123)
+#     L = 4
+#     t = randn(rng, L - 1)
+#     U = randn(rng, L)
 
-    # particle-hole symmetric spectrum across all symmetry combinations: a many-body
-    # integration check that the staggered η-gauge e_hopping (verified element-wise per-bond
-    # above) assembles correctly into a chain under SU2 particle symmetry.
-    H_triv = hubbard_hamiltonian_ph(Trivial, Trivial; t, U)
-    vals_triv = expanded_eigenvalues(H_triv)
+#     # particle-hole symmetric spectrum across all symmetry combinations: a many-body
+#     # integration check that the staggered η-gauge e_hopping (verified element-wise per-bond
+#     # above) assembles correctly into a chain under SU2 particle symmetry.
+#     H_triv = hubbard_hamiltonian_ph(Trivial, Trivial; t, U)
+#     vals_triv = expanded_eigenvalues(H_triv)
 
-    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
-        particle_symmetry == spin_symmetry == Trivial && continue
-        H_symm = hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
-        vals_symm = expanded_eigenvalues(H_symm)
-        @test vals_triv ≈ vals_symm
-    end
-end
+#     for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+#         particle_symmetry == spin_symmetry == Trivial && continue
+#         H_symm = hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
+#         vals_symm = expanded_eigenvalues(H_symm)
+#         @test vals_triv ≈ vals_symm
+#     end
+# end
 
-@testset "Exact diagonalisation" begin
-    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
-        has_e_num(particle_symmetry, spin_symmetry) || continue
-        rng = StableRNG(123)
+# @testset "Exact diagonalisation" begin
+#     for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+#         has_e_num(particle_symmetry, spin_symmetry) || continue
+#         rng = StableRNG(123)
 
-        L = 2
-        t, U = rand(rng, 5)
-        mu = 0.0
-        E⁻ = U / 2 - sqrt((U / 2)^2 + 4 * t^2)
-        E⁺ = U / 2 + sqrt((U / 2)^2 + 4 * t^2)
-        H_triv = hubbard_hamiltonian(
-            particle_symmetry, spin_symmetry;
-            t = fill(t, L - 1), U = fill(U, L), mu = fill(mu, L)
-        )
+#         L = 2
+#         t, U = rand(rng, 5)
+#         mu = 0.0
+#         E⁻ = U / 2 - sqrt((U / 2)^2 + 4 * t^2)
+#         E⁺ = U / 2 + sqrt((U / 2)^2 + 4 * t^2)
+#         H_triv = hubbard_hamiltonian(
+#             particle_symmetry, spin_symmetry;
+#             t = fill(t, L - 1), U = fill(U, L), mu = fill(mu, L)
+#         )
 
-        # Values based on https://arxiv.org/pdf/0807.4878. Introduction to Hubbard Model and Exact Diagonalization
-        true_eigenvals = sort(
-            vcat(fill(-t, 2), E⁻, fill(0, 4), fill(t, 2), fill(U - t, 2), U, E⁺, fill(U + t, 2), 2 * U)
-        )
-        eigenvals = expanded_eigenvalues(H_triv)
-        @test eigenvals ≈ true_eigenvals
-    end
-end
+#         # Values based on https://arxiv.org/pdf/0807.4878. Introduction to Hubbard Model and Exact Diagonalization
+#         true_eigenvals = sort(
+#             vcat(fill(-t, 2), E⁻, fill(0, 4), fill(t, 2), fill(U - t, 2), U, E⁺, fill(U + t, 2), 2 * U)
+#         )
+#         eigenvals = expanded_eigenvalues(H_triv)
+#         @test eigenvals ≈ true_eigenvals
+#     end
+# end

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -112,211 +112,211 @@ end
     end
 end
 
-# @testset "regression values" begin
-#     # staggered-gauge e_hopping with SU2 x SU2 symmetry
-#     t = e_hopping(ComplexF64, SU2Irrep, SU2Irrep)
-#     @test_throws ArgumentError e_hopping(Float64, SU2Irrep, SU2Irrep)
-#     I2 = sectortype(t)
-#     even = I2(0, 1 // 2, 0)
-#     odd = I2(1, 0, 1 // 2)
-#     f1 = only(fusiontrees((odd, odd), one(I2)))
-#     f2 = only(fusiontrees((even, even), one(I2)))
-#     f3 = only(fusiontrees((even, odd), I2((1, 1 // 2, 1 // 2))))
-#     f4 = only(fusiontrees((odd, even), I2((1, 1 // 2, 1 // 2))))
-#     @test all(t[f1, f2] .≈ 2im) && all(t[f2, f1] .≈ -2im)
-#     @test all(t[f3, f4] .≈ im) && all(t[f4, f3] .≈ -im)
+@testset "regression values" begin
+    # staggered-gauge e_hopping with SU2 x SU2 symmetry
+    t = e_hopping(ComplexF64, SU2Irrep, SU2Irrep)
+    @test_throws ArgumentError e_hopping(Float64, SU2Irrep, SU2Irrep)
+    I2 = sectortype(t)
+    even = I2(0, 1 // 2, 0)
+    odd = I2(1, 0, 1 // 2)
+    f1 = only(fusiontrees((odd, odd), one(I2)))
+    f2 = only(fusiontrees((even, even), one(I2)))
+    f3 = only(fusiontrees((even, odd), I2((1, 1 // 2, 1 // 2))))
+    f4 = only(fusiontrees((odd, even), I2((1, 1 // 2, 1 // 2))))
+    @test all(t[f1, f2] .≈ 2im) && all(t[f2, f1] .≈ -2im)
+    @test all(t[f3, f4] .≈ im) && all(t[f4, f3] .≈ -im)
 
-#     # e_plus_e_min moves a particle from the second site to the first:
-#     # ⟨↑,0|e⁺e⁻|0,↑⟩ = 1 while ⟨0,↑|e⁺e⁻|↑,0⟩ = 0, in every symmetric version
-#     # (regression check: the hand-written SU2-spin versions used to be transposed)
-#     for (P, S) in Iterators.product(particle_syms, spin_syms)
-#         has_e_pm(P, S) || continue
-#         A = convert(Array, e_plus_e_min(ComplexF64, P, S))
-#         U = convert(Array, basis_transform(P, S))
-#         i0 = findfirst(==(1), U[:, 1]) # dense index of |0⟩
-#         iu = findfirst(==(1), U[:, 3]) # dense index of |↑⟩
-#         @test A[iu, i0, i0, iu] ≈ 1
-#         @test abs(A[i0, iu, iu, i0]) < 1.0e-12
-#     end
-# end
+    # e_plus_e_min moves a particle from the second site to the first:
+    # ⟨↑,0|e⁺e⁻|0,↑⟩ = 1 while ⟨0,↑|e⁺e⁻|↑,0⟩ = 0, in every symmetric version
+    # (regression check: the hand-written SU2-spin versions used to be transposed)
+    for (P, S) in Iterators.product(particle_syms, spin_syms)
+        has_e_pm(P, S) || continue
+        A = convert(Array, e_plus_e_min(ComplexF64, P, S))
+        U = convert(Array, basis_transform(P, S))
+        i0 = findfirst(==(1), U[:, 1]) # dense index of |0⟩
+        iu = findfirst(==(1), U[:, 3]) # dense index of |↑⟩
+        @test A[iu, i0, i0, iu] ≈ 1
+        @test abs(A[i0, iu, iu, i0]) < 1.0e-12
+    end
+end
 
-# @testset "basic properties" begin
-#     for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
-#         # test hopping operator
-#         if has_e_pm(particle_symmetry, spin_symmetry)
-#             epem = e_plus_e_min(particle_symmetry, spin_symmetry)
-#             emep = e_min_e_plus(particle_symmetry, spin_symmetry)
-#             @test epem' ≈ -emep ≈ swap_2sites(epem)
-#         else
-#             @test_throws ArgumentError e_plus_e_min(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError e_min_e_plus(particle_symmetry, spin_symmetry)
-#         end
-#         ehop = e_hopping(particle_symmetry, spin_symmetry)
-#         @test ehop' ≈ ehop
+@testset "basic properties" begin
+    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+        # test hopping operator
+        if has_e_pm(particle_symmetry, spin_symmetry)
+            epem = e_plus_e_min(particle_symmetry, spin_symmetry)
+            emep = e_min_e_plus(particle_symmetry, spin_symmetry)
+            @test epem' ≈ -emep ≈ swap_2sites(epem)
+        else
+            @test_throws ArgumentError e_plus_e_min(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError e_min_e_plus(particle_symmetry, spin_symmetry)
+        end
+        ehop = e_hopping(particle_symmetry, spin_symmetry)
+        @test ehop' ≈ ehop
 
-#         if has_u_num(particle_symmetry, spin_symmetry)
-#             dpdm = d_plus_d_min(particle_symmetry, spin_symmetry)
-#             dmdp = d_min_d_plus(particle_symmetry, spin_symmetry)
-#             @test dpdm' ≈ -dmdp ≈ swap_2sites(dpdm)
-#             upum = u_plus_u_min(particle_symmetry, spin_symmetry)
-#             umup = u_min_u_plus(particle_symmetry, spin_symmetry)
-#             @test upum' ≈ -umup ≈ swap_2sites(upum)
-#         else
-#             @test_throws ArgumentError u_plus_u_min(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError u_min_u_plus(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError d_plus_d_min(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError d_min_d_plus(particle_symmetry, spin_symmetry)
-#         end
+        if has_u_num(particle_symmetry, spin_symmetry)
+            dpdm = d_plus_d_min(particle_symmetry, spin_symmetry)
+            dmdp = d_min_d_plus(particle_symmetry, spin_symmetry)
+            @test dpdm' ≈ -dmdp ≈ swap_2sites(dpdm)
+            upum = u_plus_u_min(particle_symmetry, spin_symmetry)
+            umup = u_min_u_plus(particle_symmetry, spin_symmetry)
+            @test upum' ≈ -umup ≈ swap_2sites(upum)
+        else
+            @test_throws ArgumentError u_plus_u_min(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError u_min_u_plus(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError d_plus_d_min(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError d_min_d_plus(particle_symmetry, spin_symmetry)
+        end
 
-#         # test number operator
-#         if has_u_num(particle_symmetry, spin_symmetry)
-#             @test e_num(particle_symmetry, spin_symmetry) ≈
-#                 u_num(particle_symmetry, spin_symmetry) +
-#                 d_num(particle_symmetry, spin_symmetry)
-#             @test ud_num(particle_symmetry, spin_symmetry) ≈
-#                 u_num(particle_symmetry, spin_symmetry) *
-#                 d_num(particle_symmetry, spin_symmetry) ≈
-#                 d_num(particle_symmetry, spin_symmetry) *
-#                 u_num(particle_symmetry, spin_symmetry)
-#         end
-#         if has_e_num(particle_symmetry, spin_symmetry)
-#             @test half_ud_num(particle_symmetry, spin_symmetry) ≈
-#                 ud_num(particle_symmetry, spin_symmetry) -
-#                 e_num(particle_symmetry, spin_symmetry) / 2 +
-#                 id(hubbard_space(particle_symmetry, spin_symmetry)) / 4
-#         else
-#             @test_throws ArgumentError e_num(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError ud_num(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError h_num(particle_symmetry, spin_symmetry)
-#         end
+        # test number operator
+        if has_u_num(particle_symmetry, spin_symmetry)
+            @test e_num(particle_symmetry, spin_symmetry) ≈
+                u_num(particle_symmetry, spin_symmetry) +
+                d_num(particle_symmetry, spin_symmetry)
+            @test ud_num(particle_symmetry, spin_symmetry) ≈
+                u_num(particle_symmetry, spin_symmetry) *
+                d_num(particle_symmetry, spin_symmetry) ≈
+                d_num(particle_symmetry, spin_symmetry) *
+                u_num(particle_symmetry, spin_symmetry)
+        end
+        if has_e_num(particle_symmetry, spin_symmetry)
+            @test half_ud_num(particle_symmetry, spin_symmetry) ≈
+                ud_num(particle_symmetry, spin_symmetry) -
+                e_num(particle_symmetry, spin_symmetry) / 2 +
+                id(hubbard_space(particle_symmetry, spin_symmetry)) / 4
+        else
+            @test_throws ArgumentError e_num(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError ud_num(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError h_num(particle_symmetry, spin_symmetry)
+        end
 
-#         # test singlet operators
-#         if has_pair(particle_symmetry, spin_symmetry)
-#             singm = singlet_min(particle_symmetry, spin_symmetry)
-#             umdm = u_min_d_min(particle_symmetry, spin_symmetry)
-#             dmum = d_min_u_min(particle_symmetry, spin_symmetry)
-#             @test swap_2sites(umdm) ≈ -dmum
-#             @test swap_2sites(singm) ≈ singm
-#             @test singm ≈ (-umdm + dmum) / sqrt(2)
-#             updp = u_plus_d_plus(particle_symmetry, spin_symmetry)
-#             dpup = d_plus_u_plus(particle_symmetry, spin_symmetry)
-#             @test swap_2sites(updp) ≈ -dpup
-#         elseif has_singlet(particle_symmetry, spin_symmetry)
-#             singm = singlet_min(particle_symmetry, spin_symmetry)
-#             @test swap_2sites(singm) ≈ singm
-#         else
-#             @test_throws ArgumentError singlet_plus(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError u_plus_d_plus(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError d_plus_u_plus(particle_symmetry, spin_symmetry)
-#         end
+        # test singlet operators
+        if has_pair(particle_symmetry, spin_symmetry)
+            singm = singlet_min(particle_symmetry, spin_symmetry)
+            umdm = u_min_d_min(particle_symmetry, spin_symmetry)
+            dmum = d_min_u_min(particle_symmetry, spin_symmetry)
+            @test swap_2sites(umdm) ≈ -dmum
+            @test swap_2sites(singm) ≈ singm
+            @test singm ≈ (-umdm + dmum) / sqrt(2)
+            updp = u_plus_d_plus(particle_symmetry, spin_symmetry)
+            dpup = d_plus_u_plus(particle_symmetry, spin_symmetry)
+            @test swap_2sites(updp) ≈ -dpup
+        elseif has_singlet(particle_symmetry, spin_symmetry)
+            singm = singlet_min(particle_symmetry, spin_symmetry)
+            @test swap_2sites(singm) ≈ singm
+        else
+            @test_throws ArgumentError singlet_plus(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError u_plus_d_plus(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError d_plus_u_plus(particle_symmetry, spin_symmetry)
+        end
 
-#         # test triplet operators
-#         if has_triplet(particle_symmetry, spin_symmetry)
-#             umum = u_min_u_min(particle_symmetry, spin_symmetry)
-#             dmdm = d_min_d_min(particle_symmetry, spin_symmetry)
-#             upup = u_plus_u_plus(particle_symmetry, spin_symmetry)
-#             dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry)
-#             @test swap_2sites(umum) ≈ -umum
-#             @test swap_2sites(dmdm) ≈ -dmdm
-#             @test swap_2sites(upup) ≈ -upup
-#             @test swap_2sites(dpdp) ≈ -dpdp
-#         else
-#             @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError u_plus_u_plus(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError d_plus_d_plus(particle_symmetry, spin_symmetry)
-#         end
+        # test triplet operators
+        if has_triplet(particle_symmetry, spin_symmetry)
+            umum = u_min_u_min(particle_symmetry, spin_symmetry)
+            dmdm = d_min_d_min(particle_symmetry, spin_symmetry)
+            upup = u_plus_u_plus(particle_symmetry, spin_symmetry)
+            dpdp = d_plus_d_plus(particle_symmetry, spin_symmetry)
+            @test swap_2sites(umum) ≈ -umum
+            @test swap_2sites(dmdm) ≈ -dmdm
+            @test swap_2sites(upup) ≈ -upup
+            @test swap_2sites(dpdp) ≈ -dpdp
+        else
+            @test_throws ArgumentError u_min_u_min(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError d_min_d_min(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError u_plus_u_plus(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError d_plus_d_plus(particle_symmetry, spin_symmetry)
+        end
 
-#         # test spin operator
-#         if has_spin_ops(particle_symmetry, spin_symmetry)
-#             test_spin_algebra(
-#                 S_x(particle_symmetry, spin_symmetry),
-#                 S_y(particle_symmetry, spin_symmetry),
-#                 S_z(particle_symmetry, spin_symmetry),
-#             )
-#             # test S_plus and S_min
-#             @test S_plus_S_min(particle_symmetry, spin_symmetry) ≈
-#                 S_plus(particle_symmetry, spin_symmetry) ⊗
-#                 S_min(particle_symmetry, spin_symmetry)
-#             @test S_min_S_plus(particle_symmetry, spin_symmetry) ≈
-#                 S_min(particle_symmetry, spin_symmetry) ⊗
-#                 S_plus(particle_symmetry, spin_symmetry)
-#         else
-#             @test_throws ArgumentError S_plus(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError S_min(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError S_x(particle_symmetry, spin_symmetry)
-#             @test_throws ArgumentError S_y(particle_symmetry, spin_symmetry)
-#             if !has_S_z(particle_symmetry, spin_symmetry)
-#                 @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry)
-#             end
-#         end
-#     end
-# end
+        # test spin operator
+        if has_spin_ops(particle_symmetry, spin_symmetry)
+            test_spin_algebra(
+                S_x(particle_symmetry, spin_symmetry),
+                S_y(particle_symmetry, spin_symmetry),
+                S_z(particle_symmetry, spin_symmetry),
+            )
+            # test S_plus and S_min
+            @test S_plus_S_min(particle_symmetry, spin_symmetry) ≈
+                S_plus(particle_symmetry, spin_symmetry) ⊗
+                S_min(particle_symmetry, spin_symmetry)
+            @test S_min_S_plus(particle_symmetry, spin_symmetry) ≈
+                S_min(particle_symmetry, spin_symmetry) ⊗
+                S_plus(particle_symmetry, spin_symmetry)
+        else
+            @test_throws ArgumentError S_plus(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError S_min(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError S_x(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError S_y(particle_symmetry, spin_symmetry)
+            if !has_S_z(particle_symmetry, spin_symmetry)
+                @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry)
+            end
+        end
+    end
+end
 
-# function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu)
-#     @assert length(t) + 1 == length(U) == length(mu)
-#     hopping = e_hopping(particle_symmetry, spin_symmetry)
-#     interaction = ud_num(particle_symmetry, spin_symmetry)
-#     chemical_potential = e_num(particle_symmetry, spin_symmetry)
-#     H = operator_sum(hopping, -t) +
-#         operator_sum(interaction, U) +
-#         operator_sum(chemical_potential, -mu)
+function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu)
+    @assert length(t) + 1 == length(U) == length(mu)
+    hopping = e_hopping(particle_symmetry, spin_symmetry)
+    interaction = ud_num(particle_symmetry, spin_symmetry)
+    chemical_potential = e_num(particle_symmetry, spin_symmetry)
+    H = operator_sum(hopping, -t) +
+        operator_sum(interaction, U) +
+        operator_sum(chemical_potential, -mu)
 
-#     return H
-# end
-# # particle-hole symmetric Hamiltonian (mu = U/2), compatible with all symmetries
-# function hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
-#     @assert length(t) + 1 == length(U)
-#     hopping = e_hopping(particle_symmetry, spin_symmetry)
-#     interaction = half_ud_num(particle_symmetry, spin_symmetry)
-#     H = operator_sum(hopping, -t) +
-#         operator_sum(interaction, U)
-#     return H
-# end
+    return H
+end
+# particle-hole symmetric Hamiltonian (mu = U/2), compatible with all symmetries
+function hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
+    @assert length(t) + 1 == length(U)
+    hopping = e_hopping(particle_symmetry, spin_symmetry)
+    interaction = half_ud_num(particle_symmetry, spin_symmetry)
+    H = operator_sum(hopping, -t) +
+        operator_sum(interaction, U)
+    return H
+end
 
-# @testset "spectrum" begin
-#     rng = StableRNG(123)
-#     L = 4
-#     t = randn(rng, L - 1)
-#     U = randn(rng, L)
+@testset "spectrum" begin
+    rng = StableRNG(123)
+    L = 4
+    t = randn(rng, L - 1)
+    U = randn(rng, L)
 
-#     # particle-hole symmetric spectrum across all symmetry combinations: a many-body
-#     # integration check that the staggered η-gauge e_hopping (verified element-wise per-bond
-#     # above) assembles correctly into a chain under SU2 particle symmetry.
-#     H_triv = hubbard_hamiltonian_ph(Trivial, Trivial; t, U)
-#     vals_triv = expanded_eigenvalues(H_triv)
+    # particle-hole symmetric spectrum across all symmetry combinations: a many-body
+    # integration check that the staggered η-gauge e_hopping (verified element-wise per-bond
+    # above) assembles correctly into a chain under SU2 particle symmetry.
+    H_triv = hubbard_hamiltonian_ph(Trivial, Trivial; t, U)
+    vals_triv = expanded_eigenvalues(H_triv)
 
-#     for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
-#         particle_symmetry == spin_symmetry == Trivial && continue
-#         H_symm = hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
-#         vals_symm = expanded_eigenvalues(H_symm)
-#         @test vals_triv ≈ vals_symm
-#     end
-# end
+    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+        particle_symmetry == spin_symmetry == Trivial && continue
+        H_symm = hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
+        vals_symm = expanded_eigenvalues(H_symm)
+        @test vals_triv ≈ vals_symm
+    end
+end
 
-# @testset "Exact diagonalisation" begin
-#     for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
-#         has_e_num(particle_symmetry, spin_symmetry) || continue
-#         rng = StableRNG(123)
+@testset "Exact diagonalisation" begin
+    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+        has_e_num(particle_symmetry, spin_symmetry) || continue
+        rng = StableRNG(123)
 
-#         L = 2
-#         t, U = rand(rng, 5)
-#         mu = 0.0
-#         E⁻ = U / 2 - sqrt((U / 2)^2 + 4 * t^2)
-#         E⁺ = U / 2 + sqrt((U / 2)^2 + 4 * t^2)
-#         H_triv = hubbard_hamiltonian(
-#             particle_symmetry, spin_symmetry;
-#             t = fill(t, L - 1), U = fill(U, L), mu = fill(mu, L)
-#         )
+        L = 2
+        t, U = rand(rng, 5)
+        mu = 0.0
+        E⁻ = U / 2 - sqrt((U / 2)^2 + 4 * t^2)
+        E⁺ = U / 2 + sqrt((U / 2)^2 + 4 * t^2)
+        H_triv = hubbard_hamiltonian(
+            particle_symmetry, spin_symmetry;
+            t = fill(t, L - 1), U = fill(U, L), mu = fill(mu, L)
+        )
 
-#         # Values based on https://arxiv.org/pdf/0807.4878. Introduction to Hubbard Model and Exact Diagonalization
-#         true_eigenvals = sort(
-#             vcat(fill(-t, 2), E⁻, fill(0, 4), fill(t, 2), fill(U - t, 2), U, E⁺, fill(U + t, 2), 2 * U)
-#         )
-#         eigenvals = expanded_eigenvalues(H_triv)
-#         @test eigenvals ≈ true_eigenvals
-#     end
-# end
+        # Values based on https://arxiv.org/pdf/0807.4878. Introduction to Hubbard Model and Exact Diagonalization
+        true_eigenvals = sort(
+            vcat(fill(-t, 2), E⁻, fill(0, 4), fill(t, 2), fill(U - t, 2), U, E⁺, fill(U + t, 2), 2 * U)
+        )
+        eigenvals = expanded_eigenvalues(H_triv)
+        @test eigenvals ≈ true_eigenvals
+    end
+end

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -83,7 +83,7 @@ end
                 (has_u_num(particle_symmetry, spin_symmetry), (u_num, d_num)),
                 (has_e_pm(particle_symmetry, spin_symmetry), (e_plus_e_min,)),
                 (has_singlet(particle_symmetry, spin_symmetry), (singlet_plus,)),
-                (has_paircor(partialsort, spin_symmetry), (singlet_plus_singlet_min_3site, singlet_plus_singlet_min_4site)),
+                (has_paircor(particle_symmetry, spin_symmetry), (singlet_plus_singlet_min_3site, singlet_plus_singlet_min_4site)),
                 (has_S_z(particle_symmetry, spin_symmetry), (S_plus_S_min, S_min_S_plus)),
             )
             for f in fs

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -40,6 +40,12 @@ implemented_symmetries = [
                     test_operator(O, O_triv)
                     test_operator(O * O', O_triv * O_triv')
                 end
+
+                if spin_symmetry != SU2Irrep
+                    O = threesite(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
+                    O_triv = threesite(ComplexF64, Trivial, Trivial; slave_fermion)
+                    test_operator(O, O_triv)
+                end
             else
                 @test_broken e_plus_e_min(
                     ComplexF64, particle_symmetry, spin_symmetry;

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -39,6 +39,14 @@ end
         O_triv = S_exchange(ComplexF64, Trivial, Trivial; slave_fermion)
         test_operator(O, O_triv; L)
 
+        O = Δ⁺ij_Δjk(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
+        O_triv = Δ⁺ij_Δjk(ComplexF64, Trivial, Trivial; slave_fermion)
+        test_operator(O, O_triv; L = 5)
+
+        O = Δ⁺ij_Δkl(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
+        O_triv = Δ⁺ij_Δkl(ComplexF64, Trivial, Trivial; slave_fermion)
+        test_operator(O, O_triv; L = 5)
+
         if particle_symmetry == Trivial
             O = singlet_plus(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
             O_triv = singlet_plus(ComplexF64, Trivial, Trivial; slave_fermion)
@@ -108,6 +116,11 @@ end
             @test_throws ArgumentError u_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
             @test_throws ArgumentError d_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
         end
+
+        # test 3-site singlet hopping operator
+        O_ijk = Δ⁺ij_Δjk(particle_symmetry, spin_symmetry; slave_fermion)
+        O_kji = permute(O_ijk, ((3, 2, 1), (6, 5, 4)))
+        @test O_kji ≈ O_ijk'
 
         # test triplet operators
         if particle_symmetry == Trivial && spin_symmetry == Trivial


### PR DESCRIPTION
For Hubbard and t-J models, this PR adds the singlet pair nearest-neighbor (NN) hopping (3-site) operator

```math
O_{ijk} = \Delta^\dagger_{ij} \Delta_{jk}
```

and the singlet pair correlation (4-site) operator

```math
O_{ijkl} = \Delta^\dagger_{ij} \Delta_{kl}
```

Here $\Delta^\dagger_{ij}$ is the singlet pair creation operator

```math
\Delta^\dagger_{ij} = \frac{1}{\sqrt{2}} (
    c^\dagger_{i\uparrow} c^\dagger_{j\downarrow}
    - c^\dagger_{i\downarrow} c^\dagger_{j\uparrow}
)
```

The function names are `singlet_plus_singlet_min_3site` (alias `Δ⁺ij_Δjk`) and `singlet_plus_singlet_min_4site` (alias `Δ⁺ij_Δkl`).