### PR TITLE
Fix S_exchange in Hubbard and t-J with SU(2) spin symmetry

### DIFF
--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -980,20 +980,32 @@ end
 function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
     t = n_site_operator(Val(2), elt, Trivial, SU2Irrep)
     for (s, f) in fusiontrees(t)
+        p1 = s.uncoupled[1][1].isodd
+        p2 = s.uncoupled[2][1].isodd
+        p3 = f.uncoupled[1][1].isodd
+        p4 = f.uncoupled[2][1].isodd
         l3 = f.uncoupled[1][2].j
         l4 = f.uncoupled[2][2].j
         k = f.coupled[2].j
-        t[s, f] .= (k * (k + 1) - l3 * (l3 + 1) - l4 * (l4 + 1)) / 2
+        if p1 && p2 && p3 && p4
+            t[s, f] .= (k * (k + 1) - l3 * (l3 + 1) - l4 * (l4 + 1)) / 2
+        end
     end
     return t
 end
 function S_exchange(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     t = n_site_operator(Val(2), elt, U1Irrep, SU2Irrep)
     for (s, f) in fusiontrees(t)
+        n1 = s.uncoupled[1][2].charge
+        n2 = s.uncoupled[2][2].charge
+        n3 = f.uncoupled[1][2].charge
+        n4 = f.uncoupled[2][2].charge
         l3 = f.uncoupled[1][3].j
         l4 = f.uncoupled[2][3].j
         k = f.coupled[3].j
-        t[s, f] .= (k * (k + 1) - l3 * (l3 + 1) - l4 * (l4 + 1)) / 2
+        if n1 == n2 == n3 == n4 == 1
+            t[s, f] .= (k * (k + 1) - l3 * (l3 + 1) - l4 * (l4 + 1)) / 2
+        end
     end
     return t
 end

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -69,16 +69,17 @@ function hubbard_space(::Type{SU2Irrep}, ::Type{SU2Irrep})
     )
 end
 
-# Single-site operators
-# ---------------------
-function single_site_operator(
-        elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
+function n_site_operator(
+        ::Val{N}, elt::Type{<:Number},
+        particle_symmetry::Type{<:Sector},
         spin_symmetry::Type{<:Sector}
-    )
+    ) where {N}
     V = hubbard_space(particle_symmetry, spin_symmetry)
-    return zeros(elt, V ← V)
+    return zeros(elt, V^N ← V^N)
 end
 
+# Single-site operators
+# ---------------------
 @doc """
     u_num([particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     nꜛ([particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
@@ -87,38 +88,32 @@ Return the one-body operator that counts the number of spin-up particles.
 """ u_num
 u_num(P::Type{<:Sector}, S::Type{<:Sector}) = u_num(ComplexF64, P, S)
 function u_num(elt::Type{<:Number}, (::Type{Trivial}) = Trivial, (::Type{Trivial}) = Trivial)
-    t = single_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(1), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][1, 1] = 1
     t[(I(0), I(0))][2, 2] = 1
     return t
 end
 function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
-    t = single_site_operator(elt, Trivial, U1Irrep)
+    t = n_site_operator(Val(1), elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1 // 2), dual(I(1, 1 // 2)))][1, 1] = 1
     t[(I(0, 0), dual(I(0, 0)))][2, 2] = 1
     return t
 end
-function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
-    throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
-end
 function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
-    t = single_site_operator(elt, U1Irrep, Trivial)
+    t = n_site_operator(Val(1), elt, U1Irrep, Trivial)
     I = sectortype(t)
     block(t, I(1, 1))[1, 1] = 1
     block(t, I(0, 2))[1, 1] = 1
     return t
 end
 function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
-    t = single_site_operator(elt, U1Irrep, U1Irrep)
+    t = n_site_operator(Val(1), elt, U1Irrep, U1Irrep)
     I = sectortype(t)
     block(t, I(1, 1, 1 // 2)) .= 1
     block(t, I(0, 2, 0)) .= 1
     return t
-end
-function u_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 function u_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{Trivial})
     return error("Not implemented")
@@ -126,7 +121,7 @@ end
 function u_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{U1Irrep})
     return error("Not implemented")
 end
-function u_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
+function u_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const nꜛ = u_num
@@ -139,38 +134,32 @@ Return the one-body operator that counts the number of spin-down particles.
 """ d_num
 d_num(P::Type{<:Sector}, S::Type{<:Sector}) = d_num(ComplexF64, P, S)
 function d_num(elt::Type{<:Number}, (::Type{Trivial}) = Trivial, (::Type{Trivial}) = Trivial)
-    t = single_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(1), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1))][2, 2] = 1
     t[(I(0), I(0))][2, 2] = 1
     return t
 end
 function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
-    t = single_site_operator(elt, Trivial, U1Irrep)
+    t = n_site_operator(Val(1), elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(1, -1 // 2), dual(I(1, -1 // 2)))][1, 1] = 1
     t[(I(0, 0), I(0, 0))][2, 2] = 1
     return t
 end
-function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
-    throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
-end
 function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
-    t = single_site_operator(elt, U1Irrep, Trivial)
+    t = n_site_operator(Val(1), elt, U1Irrep, Trivial)
     I = sectortype(t)
     block(t, I(1, 1))[2, 2] = 1 # expected to be [1,2]
     block(t, I(0, 2))[1, 1] = 1
     return t
 end
 function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
-    t = single_site_operator(elt, U1Irrep, U1Irrep)
+    t = n_site_operator(Val(1), elt, U1Irrep, U1Irrep)
     I = sectortype(t)
     block(t, I(1, 1, -1 // 2)) .= 1
     block(t, I(0, 2, 0)) .= 1
     return t
-end
-function d_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 function d_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{Trivial})
     return error("Not implemented")
@@ -178,7 +167,7 @@ end
 function d_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{U1Irrep})
     return error("Not implemented")
 end
-function d_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
+function d_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_num` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const nꜜ = d_num
@@ -198,14 +187,14 @@ function e_num(
         d_num(elt, particle_symmetry, spin_symmetry)
 end
 function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
-    t = single_site_operator(elt, Trivial, SU2Irrep)
+    t = n_site_operator(Val(1), elt, Trivial, SU2Irrep)
     I = sectortype(t)
     block(t, I(1, 1 // 2))[1, 1] = 1
     block(t, I(0, 0))[2, 2] = 2
     return t
 end
 function e_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    t = single_site_operator(elt, U1Irrep, SU2Irrep)
+    t = n_site_operator(Val(1), elt, U1Irrep, SU2Irrep)
     I = sectortype(t)
     block(t, I(1, 1, 1 // 2)) .= 1
     block(t, I(0, 2, 0)) .= 2
@@ -228,13 +217,13 @@ function ud_num(
         d_num(elt, particle_symmetry, spin_symmetry)
 end
 function ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
-    t = single_site_operator(elt, Trivial, SU2Irrep)
+    t = n_site_operator(Val(1), elt, Trivial, SU2Irrep)
     I = sectortype(t)
     block(t, I(0, 0))[2, 2] = 1
     return t
 end
 function ud_num(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    t = single_site_operator(elt, U1Irrep, SU2Irrep)
+    t = n_site_operator(Val(1), elt, U1Irrep, SU2Irrep)
     I = sectortype(t)
     block(t, I(0, 2, 0)) .= 1
     return t
@@ -256,7 +245,7 @@ function half_ud_num(
         (d_num(elt, particle_symmetry, spin_symmetry) - I / 2)
 end
 function half_ud_num(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
-    t = single_site_operator(elt, SU2Irrep, SU2Irrep)
+    t = n_site_operator(Val(1), elt, SU2Irrep, SU2Irrep)
     block(t, sectortype(t)(0, 1 // 2, 0)) .= 1 // 4
     block(t, sectortype(t)(1, 0, 1 // 2)) .= -1 // 4
     return t
@@ -283,21 +272,21 @@ function S_plus(P::Type{<:Sector}, S::Type{<:Sector})
     return S_plus(ComplexF64, P, S)
 end
 function S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
-    t = single_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(1), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), dual(I(1)))][1, 2] = 1.0
     return t
 end
 function S_plus(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
-    t = single_site_operator(elt, U1Irrep, Trivial)
+    t = n_site_operator(Val(1), elt, U1Irrep, Trivial)
     I = sectortype(t)
     t[(I(1, 1), dual(I(1, 1)))][1, 2] = 1.0
     return t
 end
-function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
+function S_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
     throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `U1Irrep` spin symmetry"))
 end
-function S_plus(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+function S_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`S_plus`, `S_min` are not symmetric under `SU2Irrep` spin symmetry"))
 end
 const S⁺ = S_plus
@@ -381,14 +370,6 @@ const Sᶻ = S_z
 
 # Two site operators
 # ------------------
-function two_site_operator(
-        elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
-        spin_symmetry::Type{<:Sector}
-    )
-    V = hubbard_space(particle_symmetry, spin_symmetry)
-    return zeros(elt, V ⊗ V ← V ⊗ V)
-end
-
 @doc """
     u_plus_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     u⁺u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
@@ -397,7 +378,7 @@ Return the two-body operator ``e†_{1,↑}, e_{2,↑}`` that creates a spin-up 
 """ u_plus_u_min
 u_plus_u_min(P::Type{<:Sector}, S::Type{<:Sector}) = u_plus_u_min(ComplexF64, P, S)
 function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
-    t = two_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(2), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(0), dual(I(0)), dual(I(1)))][1, 1, 1, 1] = 1
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][1, 2, 1, 2] = 1
@@ -406,7 +387,7 @@ function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return t
 end
 function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
-    t = two_site_operator(elt, Trivial, U1Irrep)
+    t = n_site_operator(Val(2), elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1 // 2), I(0, 0), dual(I(0, 0)), dual(I(1, 1 // 2)))][1, 1, 1, 1] = 1
     t[(I(1, 1 // 2), I(1, -1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 1, 2] = 1
@@ -414,11 +395,8 @@ function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
     t[(I(0, 0), I(1, -1 // 2), dual(I(1, -1 // 2)), dual(I(0, 0)))][2, 1, 1, 2] = -1
     return t
 end
-function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
-    throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
-end
 function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
-    t = two_site_operator(elt, U1Irrep, Trivial)
+    t = n_site_operator(Val(2), elt, U1Irrep, Trivial)
     I = sectortype(t)
     t[(I(1, 1), I(0, 0), dual(I(0, 0)), dual(I(1, 1)))][1, 1, 1, 1] = 1
     t[(I(1, 1), I(1, 1), dual(I(0, 0)), dual(I(0, 2)))][1, 2, 1, 1] = 1
@@ -427,7 +405,7 @@ function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
     return t
 end
 function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
-    t = two_site_operator(elt, U1Irrep, U1Irrep)
+    t = n_site_operator(Val(2), elt, U1Irrep, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1, 1 // 2), I(0, 0, 0), dual(I(0, 0, 0)), dual(I(1, 1, 1 // 2)))] .= 1
     t[(I(1, 1, 1 // 2), I(1, 1, -1 // 2), dual(I(0, 0, 0)), dual(I(0, 2, 0)))] .= 1
@@ -435,16 +413,13 @@ function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
     t[(I(0, 2, 0), I(1, 1, -1 // 2), dual(I(1, 1, -1 // 2)), dual(I(0, 2, 0)))] .= -1
     return t
 end
-function u_plus_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
-end
 function u_plus_u_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{Trivial})
     return error("Not implemented")
 end
 function u_plus_u_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{U1Irrep})
     return error("Not implemented")
 end
-function u_plus_u_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
+function u_plus_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_plus_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const u⁺u⁻ = u_plus_u_min
@@ -457,7 +432,7 @@ Return the two-body operator ``e†_{1,↓}, e_{2,↓}`` that creates a spin-dow
 """ d_plus_d_min
 d_plus_d_min(P::Type{<:Sector}, S::Type{<:Sector}) = d_plus_d_min(ComplexF64, P, S)
 function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
-    t = two_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(2), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(0), dual(I(0)), dual(I(1)))][2, 1, 1, 2] = 1
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][2, 1, 1, 2] = -1
@@ -466,7 +441,7 @@ function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return t
 end
 function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
-    t = two_site_operator(elt, Trivial, U1Irrep)
+    t = n_site_operator(Val(2), elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(1, -1 // 2), I(0, 0), dual(I(0, 0)), dual(I(1, -1 // 2)))][1, 1, 1, 1] = 1
     t[(I(1, -1 // 2), I(1, 1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 1, 2] = -1
@@ -474,11 +449,8 @@ function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
     t[(I(0, 0), I(1, 1 // 2), dual(I(1, 1 // 2)), dual(I(0, 0)))][2, 1, 1, 2] = -1
     return t
 end
-function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
-    throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
-end
 function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
-    t = two_site_operator(elt, U1Irrep, Trivial)
+    t = n_site_operator(Val(2), elt, U1Irrep, Trivial)
     I = sectortype(t)
     t[(I(1, 1), I(0, 0), dual(I(0, 0)), dual(I(1, 1)))][2, 1, 1, 2] = 1
     t[(I(1, 1), I(1, 1), dual(I(0, 0)), dual(I(0, 2)))][2, 1, 1, 1] = -1
@@ -487,7 +459,7 @@ function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
     return t
 end
 function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
-    t = two_site_operator(elt, U1Irrep, U1Irrep)
+    t = n_site_operator(Val(2), elt, U1Irrep, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1, -1 // 2), I(0, 0, 0), dual(I(0, 0, 0)), dual(I(1, 1, -1 // 2)))] .= 1
     t[(I(1, 1, -1 // 2), I(1, 1, 1 // 2), dual(I(0, 0, 0)), dual(I(0, 2, 0)))] .= -1
@@ -495,16 +467,13 @@ function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
     t[(I(0, 2, 0), I(1, 1, 1 // 2), dual(I(1, 1, 1 // 2)), dual(I(0, 2, 0)))] .= -1
     return t
 end
-function d_plus_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
-end
 function d_plus_d_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{Trivial})
     return error("Not implemented")
 end
 function d_plus_d_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{U1Irrep})
     return error("Not implemented")
 end
-function d_plus_d_min(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
+function d_plus_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_plus_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
 const d⁺d⁻ = d_plus_d_min
@@ -555,7 +524,7 @@ function e_plus_e_min(
         d_plus_d_min(elt, particle_symmetry, spin_symmetry)
 end
 function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
-    t = two_site_operator(elt, Trivial, SU2Irrep)
+    t = n_site_operator(Val(2), elt, Trivial, SU2Irrep)
     I = sectortype(t)
     f1 = only(fusiontrees((I(0, 0), I(1, 1 // 2)), I(1, 1 // 2)))
     f2 = only(fusiontrees((I(1, 1 // 2), I(0, 0)), I(1, 1 // 2)))
@@ -572,7 +541,7 @@ function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
     return t
 end
 function e_plus_e_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    t = two_site_operator(elt, U1Irrep, SU2Irrep)
+    t = n_site_operator(Val(2), elt, U1Irrep, SU2Irrep)
     I = sectortype(t)
     f1 = only(fusiontrees((I(0, 0, 0), I(1, 1, 1 // 2)), I(1, 1, 1 // 2)))
     f2 = only(fusiontrees((I(1, 1, 1 // 2), I(0, 0, 0)), I(1, 1, 1 // 2)))
@@ -622,7 +591,7 @@ function e_hopping(
 end
 function e_hopping(elt::Type{<:Number}, ::Type{SU2Irrep}, ::Type{SU2Irrep})
     elt <: Complex || throw(DomainError(elt, "SU₂ × SU₂ symmetry requires complex entries"))
-    t = two_site_operator(elt, SU2Irrep, SU2Irrep)
+    t = n_site_operator(Val(2), elt, SU2Irrep, SU2Irrep)
     I = sectortype(t)
     even = I(0, 1 // 2, 0)
     odd = I(1, 0, 1 // 2)
@@ -653,7 +622,7 @@ function u_min_d_min(P::Type{<:Sector}, S::Type{<:Sector})
     return u_min_d_min(ComplexF64, P, S)
 end
 function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
-    t = two_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(2), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 2] = -1
     t[(I(0), I(1), dual(I(1)), dual(I(0)))][1, 1, 1, 2] = 1
@@ -662,7 +631,7 @@ function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return t
 end
 function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
-    t = two_site_operator(elt, Trivial, U1Irrep)
+    t = n_site_operator(Val(2), elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(0, 0), I(0, 0), dual(I(1, 1 // 2)), dual(I(1, -1 // 2)))][1, 1, 1, 1] = -1
     t[(I(0, 0), I(1, 1 // 2), dual(I(1, 1 // 2)), dual(I(0, 0)))][1, 1, 1, 2] = 1
@@ -670,13 +639,13 @@ function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
     t[(I(1, -1 // 2), I(1, 1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 2, 2] = -1
     return t
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
+function u_min_d_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
     throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry"))
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+function u_min_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+function u_min_d_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` spin symmetry"))
 end
 const u⁻d⁻ = u_min_d_min
@@ -713,7 +682,7 @@ function d_min_u_min(P::Type{<:Sector}, S::Type{<:Sector})
     return d_min_u_min(ComplexF64, P, S)
 end
 function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
-    t = two_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(2), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 1] = -1
     t[(I(0), I(1), dual(I(1)), dual(I(0)))][1, 2, 2, 2] = -1
@@ -722,7 +691,7 @@ function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return t
 end
 function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
-    t = two_site_operator(elt, Trivial, U1Irrep)
+    t = n_site_operator(Val(2), elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(0, 0), I(0, 0), dual(I(1, -1 // 2)), dual(I(1, 1 // 2)))][1, 1, 1, 1] = -1
     t[(I(0, 0), I(1, -1 // 2), dual(I(1, -1 // 2)), dual(I(0, 0)))][1, 1, 1, 2] = -1
@@ -730,13 +699,13 @@ function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
     t[(I(1, 1 // 2), I(1, -1 // 2), dual(I(0, 0)), dual(I(0, 0)))][1, 1, 2, 2] = -1
     return t
 end
-function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
+function d_min_u_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry"))
 end
-function d_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+function d_min_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+function d_min_u_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
 end
 const d⁻u⁻ = d_min_u_min
@@ -773,7 +742,7 @@ function u_min_u_min(P::Type{<:Sector}, S::Type{<:Sector})
     return u_min_u_min(ComplexF64, P, S)
 end
 function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
-    t = two_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(2), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 1] = -1
     t[(I(0), I(1), dual(I(1)), dual(I(0)))][1, 2, 1, 2] = -1
@@ -781,20 +750,20 @@ function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][2, 2, 2, 2] = 1
     return t
 end
-function u_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
+function u_min_u_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
     throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry"))
 end
-function u_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
+function u_min_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
     throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` spin symmetry"))
 end
-function u_min_u_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+function u_min_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`u_min_u_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function u_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
-    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `U1Irrep` particle symmetry"))
+function u_min_u_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `U1Irrep` spin symmetry"))
 end
-function u_min_u_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
+function u_min_u_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    throw(ArgumentError("`u_min_u_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` spin symmetry"))
 end
 const u⁻u⁻ = u_min_u_min
 
@@ -830,7 +799,7 @@ function d_min_d_min(P::Type{<:Sector}, S::Type{<:Sector})
     return d_min_d_min(ComplexF64, P, S)
 end
 function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
-    t = two_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(2), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 2] = -1
     t[(I(0), I(1), dual(I(1)), dual(I(0)))][1, 1, 2, 2] = 1
@@ -838,20 +807,20 @@ function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][1, 1, 2, 2] = 1
     return t
 end
-function d_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
+function d_min_d_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{<:Sector})
     throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry"))
 end
-function d_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
+function d_min_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{U1Irrep})
     throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` spin symmetry"))
 end
-function d_min_d_min(elt::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
+function d_min_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{SU2Irrep})
     throw(ArgumentError("`d_min_d_min` is not symmetric under `SU2Irrep` spin symmetry"))
 end
-function d_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
-    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `U1Irrep` particle symmetry"))
+function d_min_d_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `U1Irrep` spin symmetry"))
 end
-function d_min_d_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` particle symmetry"))
+function d_min_d_min(::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
+    throw(ArgumentError("`d_min_d_min` is not symmetric under `U1Irrep` particle symmetry or under `SU2Irrep` spin symmetry"))
 end
 const d⁻d⁻ = d_min_d_min
 
@@ -877,7 +846,7 @@ const d⁺d⁺ = d_plus_d_plus
     singlet_plus(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
     singlet⁺(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 
-Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / sqrt(2)``,
+Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``,
 which creates the singlet state when acting on vaccum.
 """ singlet_plus
 function singlet_plus(P::Type{<:Sector}, S::Type{<:Sector})
@@ -895,7 +864,7 @@ end
 function singlet_plus(
         elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep}
     )
-    t = two_site_operator(elt, Trivial, SU2Irrep)
+    t = n_site_operator(Val(2), elt, Trivial, SU2Irrep)
     for (s, f) in fusiontrees(t)
         l1 = s.uncoupled[1][2].j
         l2 = s.uncoupled[2][2].j
@@ -923,7 +892,7 @@ const singlet⁺ = singlet_plus
     singlet⁻(elt, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 
 Return the adjoint of `singlet_plus` operator, which is 
-``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / sqrt(2)``
+``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / \\sqrt{2}``.
 """ singlet_min
 function singlet_min(P::Type{<:Sector}, S::Type{<:Sector})
     return singlet_min(ComplexF64, P, S)
@@ -947,25 +916,25 @@ function S_plus_S_min(P::Type{<:Sector}, S::Type{<:Sector})
     return S_plus_S_min(ComplexF64, P, S)
 end
 function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
-    t = two_site_operator(elt, Trivial, Trivial)
+    t = n_site_operator(Val(2), elt, Trivial, Trivial)
     I = sectortype(t)
     t[(I(1), I(1), dual(I(1)), dual(I(1)))][1, 2, 2, 1] = 1
     return t
 end
 function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{U1Irrep})
-    t = two_site_operator(elt, Trivial, U1Irrep)
+    t = n_site_operator(Val(2), elt, Trivial, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1 // 2), I(1, -1 // 2), dual(I(1, -1 // 2)), dual(I(1, 1 // 2)))] .= 1
     return t
 end
 function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{Trivial})
-    t = two_site_operator(elt, U1Irrep, Trivial)
+    t = n_site_operator(Val(2), elt, U1Irrep, Trivial)
     I = sectortype(t)
     t[(I(1, 1), I(1, 1), dual(I(1, 1)), dual(I(1, 1)))][1, 2, 2, 1] = 1
     return t
 end
 function S_plus_S_min(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{U1Irrep})
-    t = two_site_operator(elt, U1Irrep, U1Irrep)
+    t = n_site_operator(Val(2), elt, U1Irrep, U1Irrep)
     I = sectortype(t)
     t[(I(1, 1, 1 // 2), I(1, 1, -1 // 2), dual(I(1, 1, -1 // 2)), dual(I(1, 1, 1 // 2)))] .= 1
     return t
@@ -1009,7 +978,7 @@ function S_exchange(
     ) / 2
 end
 function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
-    t = two_site_operator(elt, Trivial, SU2Irrep)
+    t = n_site_operator(Val(2), elt, Trivial, SU2Irrep)
     for (s, f) in fusiontrees(t)
         l3 = f.uncoupled[1][2].j
         l4 = f.uncoupled[2][2].j
@@ -1019,7 +988,7 @@ function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{SU2Irrep})
     return t
 end
 function S_exchange(elt::Type{<:Number}, ::Type{U1Irrep}, ::Type{SU2Irrep})
-    t = two_site_operator(elt, U1Irrep, SU2Irrep)
+    t = n_site_operator(Val(2), elt, U1Irrep, SU2Irrep)
     for (s, f) in fusiontrees(t)
         l3 = f.uncoupled[1][3].j
         l4 = f.uncoupled[2][3].j

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -19,6 +19,7 @@ implemented_symmetries = [
         if (particle_symmetry, spin_symmetry) in implemented_symmetries
             space = @inferred hubbard_space(particle_symmetry, spin_symmetry)
 
+            # SU(2) particle symmetry
             if particle_symmetry == spin_symmetry == SU2Irrep
                 O = e_hopping(ComplexF64, SU2Irrep, SU2Irrep)
                 O_triv = e_hopping(ComplexF64, Trivial, Trivial)
@@ -33,8 +34,7 @@ implemented_symmetries = [
             if particle_symmetry == Trivial
                 O = singlet_plus(ComplexF64, Trivial, SU2Irrep)
                 O_triv = singlet_plus(ComplexF64, Trivial, Trivial)
-                test_operator(O, O_triv) # eigenvalues are all 0
-                test_operator(O * O', O_triv * O_triv')
+                test_operator(O, O_triv)
             end
 
             O = e_plus_e_min(ComplexF64, particle_symmetry, spin_symmetry)

--- a/test/testsetup.jl
+++ b/test/testsetup.jl
@@ -7,7 +7,10 @@ using TensorKit
 using TensorKit: scalartype
 using LinearAlgebra: eigvals
 
-function operator_sum(O::AbstractTensorMap; L::Int = 4)
+const default_x = 0.361 + 0.729im
+const default_L = 4
+
+function operator_sum(O::AbstractTensorMap; L::Int = default_L)
     I = id(space(O, 1))
     n = numin(O)
     return sum(1:(L - n + 1)) do i
@@ -20,20 +23,27 @@ function swap_2sites(op::AbstractTensorMap{T, S, 2, 2}) where {T, S}
 end
 
 function test_operator(
-        O1::AbstractTensorMap, O2::AbstractTensorMap; L::Int = 4,
-        isapproxkwargs...
+        O1::AbstractTensorMap, O2::AbstractTensorMap;
+        x::Number = default_x, L::Int = default_L, isapproxkwargs...
     )
-    eigenvals1 = expanded_eigenvalues(O1; L)
-    eigenvals2 = expanded_eigenvalues(O2; L)
+    eigenvals1 = expanded_eigenvalues(O1; x, L)
+    eigenvals2 = expanded_eigenvalues(O2; x, L)
     return @test isapprox(eigenvals1, eigenvals2; isapproxkwargs...)
 end
 
-function expanded_eigenvalues(O1::AbstractTensorMap; L::Int = 4)
-    H = operator_sum(O1; L)
+function round_and_sort(evs::Vector{<:Number}; digits = 12)
+    evs2 = round.(evs; digits)
+    return sort!(evs2; by = z -> (real(z), imag(z)))
+end
+
+function expanded_eigenvalues(
+        O::AbstractTensorMap; x::Number = default_x, L::Int = default_L
+    )
+    H = operator_sum(O + x * O'; L)
     eigenvals = mapreduce(vcat, pairs(eigvals(H))) do (c, vals)
         return repeat(vals, dim(c))
     end
-    return sort!(eigenvals; by = real)
+    return round_and_sort(eigenvals)
 end
 
 end

--- a/test/testsetup.jl
+++ b/test/testsetup.jl
@@ -10,6 +10,13 @@ using LinearAlgebra: eigvals
 const default_x = 0.361 + 0.729im
 const default_L = 4
 
+# utility function to sort a complex vector
+# rounding to eliminate real/imag part very close to 0
+function round_and_sort(evs::Vector{<:Number}; digits = 12)
+    evs2 = round.(evs; digits)
+    return sort!(evs2; by = z -> (real(z), imag(z)))
+end
+
 function operator_sum(O::AbstractTensorMap; L::Int = default_L)
     I = id(space(O, 1))
     n = numin(O)
@@ -26,24 +33,17 @@ function test_operator(
         O1::AbstractTensorMap, O2::AbstractTensorMap;
         x::Number = default_x, L::Int = default_L, isapproxkwargs...
     )
-    eigenvals1 = expanded_eigenvalues(O1; x, L)
-    eigenvals2 = expanded_eigenvalues(O2; x, L)
+    eigenvals1 = round_and_sort(expanded_eigenvalues(O1 + x * O1'; L))
+    eigenvals2 = round_and_sort(expanded_eigenvalues(O2 + x * O2'; L))
     return @test isapprox(eigenvals1, eigenvals2; isapproxkwargs...)
 end
 
-function round_and_sort(evs::Vector{<:Number}; digits = 12)
-    evs2 = round.(evs; digits)
-    return sort!(evs2; by = z -> (real(z), imag(z)))
-end
-
-function expanded_eigenvalues(
-        O::AbstractTensorMap; x::Number = default_x, L::Int = default_L
-    )
-    H = operator_sum(O + x * O'; L)
+function expanded_eigenvalues(O::AbstractTensorMap; L::Int = default_L)
+    H = operator_sum(O; L)
     eigenvals = mapreduce(vcat, pairs(eigvals(H))) do (c, vals)
         return repeat(vals, dim(c))
     end
-    return round_and_sort(eigenvals)
+    return sort!(eigenvals; by = real)
 end
 
 end

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -38,7 +38,6 @@ implemented_symmetries = [
                     O = singlet_plus(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
                     O_triv = singlet_plus(ComplexF64, Trivial, Trivial; slave_fermion)
                     test_operator(O, O_triv)
-                    test_operator(O * O', O_triv * O_triv')
                 end
             else
                 @test_broken e_plus_e_min(


### PR DESCRIPTION
This PR fixed `S_exchange in Hubbard and t-J with SU(2) spin symmetry`. Previously some elements involving doubly-occupied states are mistakably put in.

To catch this error, I updated `test_operator` to check the eigenvalues of `O + x * O'` instead of just `O`. We can still discuss more robust ways to test symmetric operators in #46.

In the meantime, I also fixed some error messages.