### PR TITLE
Add @operator macro to reduce operator boilerplate

### DIFF
--- a/src/bosonoperators.jl
+++ b/src/bosonoperators.jl
@@ -2,7 +2,7 @@ module BosonOperators
 
 using TensorKit
 using LinearAlgebra: I
-import ..TensorKitTensors: symmetrize, desymmetrize
+import ..TensorKitTensors: symmetrize, desymmetrize, @operator
 
 export boson_space, basis_transform
 export b_plus, b_min, b_num
@@ -45,14 +45,19 @@ function basis_transform(symmetry::Type{<:Sector}; cutoff::Integer)
     return TensorMap(Matrix{Int}(I, cutoff + 1, cutoff + 1), V ← boson_space(Trivial; cutoff))
 end
 
+# Symmetrize a boson operator through its basis transformation
+_symmetrize_operator(O::AbstractTensorMap, symmetry::Type{<:Sector}; kwargs...) =
+    symmetrize(O, basis_transform(symmetry; kwargs...), boson_space(symmetry; kwargs...))
+
 # Single-site operators
 # ---------------------
-@doc """
+"""
     b_min([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     b⁻([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic annihilation operator, with a maximum of `cutoff` bosons per site.
-""" b_min
+"""
+@operator b⁻ b_min(::Type{<:Number}, ::Type{<:Sector}; cutoff)
 function b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     pspace = boson_space(Trivial; cutoff)
     b⁻ = zeros(elt, pspace ← pspace)
@@ -61,14 +66,14 @@ function b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     end
     return b⁻
 end
-const b⁻ = b_min
 
-@doc """
+"""
     b_plus([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     b⁺([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic creation operator, with a maximum of `cutoff` bosons per site.
-""" b_plus
+"""
+@operator b⁺ b_plus(::Type{<:Number}, ::Type{<:Sector}; cutoff)
 function b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     pspace = boson_space(Trivial; cutoff)
     b⁺ = zeros(elt, pspace ← pspace)
@@ -77,14 +82,14 @@ function b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     end
     return b⁺
 end
-const b⁺ = b_plus
 
-@doc """
+"""
     b_num([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     n([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic number operator, with a maximum of `cutoff` bosons per site.
-""" b_num
+"""
+@operator n b_num(::Type{<:Number}, ::Type{<:Sector}; cutoff)
 function b_num(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     pspace = boson_space(Trivial; cutoff)
     n = zeros(elt, pspace ← pspace)
@@ -93,88 +98,68 @@ function b_num(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     end
     return n
 end
-const n = b_num
 
 # Two site operators
 # ------------------
-@doc """
+"""
     b_plus_b_plus([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     b⁺b⁺([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic pair-creation operator, with a maximum of `cutoff` bosons per site.
-""" b_plus_b_plus
+"""
+@operator b⁺b⁺ b_plus_b_plus(::Type{<:Number}, ::Type{<:Sector}; cutoff)
 function b_plus_b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     b⁺ = b_plus(elt, Trivial; cutoff)
     return b⁺ ⊗ b⁺
 end
-const b⁺b⁺ = b_plus_b_plus
 
-@doc """
+"""
     b_plus_b_min([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     b⁺b⁻([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic left-hopping operator, with a maximum of `cutoff` bosons per site.
-""" b_plus_b_min
+"""
+@operator b⁺b⁻ b_plus_b_min(::Type{<:Number}, ::Type{<:Sector}; cutoff)
 function b_plus_b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     b⁺ = b_plus(elt, Trivial; cutoff)
     b⁻ = b_min(elt, Trivial; cutoff)
     return b⁺ ⊗ b⁻
 end
-const b⁺b⁻ = b_plus_b_min
 
-@doc """
+"""
     b_min_b_plus([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     b⁻b⁺([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic right-hopping operator, with a maximum of `cutoff` bosons per site.
-""" b_min_b_plus
+"""
+@operator b⁻b⁺ b_min_b_plus(::Type{<:Number}, ::Type{<:Sector}; cutoff)
 function b_min_b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     b⁺ = b_plus(elt, Trivial; cutoff)
     b⁻ = b_min(elt, Trivial; cutoff)
     return b⁻ ⊗ b⁺
 end
-const b⁻b⁺ = b_min_b_plus
 
-@doc """
+"""
     b_min_b_min([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     b⁻b⁻([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 The truncated bosonic pair-annihilation operator, with a maximum of `cutoff` bosons per site.
-""" b_min_b_min
+"""
+@operator b⁻b⁻ b_min_b_min(::Type{<:Number}, ::Type{<:Sector}; cutoff)
 function b_min_b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     b⁻ = b_min(elt, Trivial; cutoff)
     return b⁻ ⊗ b⁻
 end
-const b⁻b⁻ = b_min_b_min
 
-@doc """
+"""
     b_hopping([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
     b_hop([elt::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff::Integer)
 
 Return the two-body operator that describes a particle that hops between the first and the second site.
-""" b_hopping
+"""
+@operator b_hop b_hopping(::Type{<:Number}, ::Type{<:Sector}; cutoff)
 function b_hopping(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     return b_plus_b_min(elt, Trivial; cutoff) + b_min_b_plus(elt, Trivial; cutoff)
-end
-const b_hop = b_hopping
-
-# Symmetric operators and default arguments
-# -----------------------------------------
-# The symmetric operators are automatically generated from their `Trivial` counterparts
-# through `symmetrize` and `basis_transform`. Operators that are incompatible with a given
-# symmetry throw an `ArgumentError`.
-for opname in
-    (:b_min, :b_plus, :b_num, :b_plus_b_plus, :b_plus_b_min, :b_min_b_plus, :b_min_b_min, :b_hopping)
-    @eval begin
-        $opname(; kwargs...) = $opname(ComplexF64, Trivial; kwargs...)
-        $opname(elt::Type{<:Number}; kwargs...) = $opname(elt, Trivial; kwargs...)
-        $opname(symmetry::Type{<:Sector}; kwargs...) = $opname(ComplexF64, symmetry; kwargs...)
-        function $opname(elt::Type{<:Number}, symmetry::Type{<:Sector}; cutoff::Integer)
-            O = $opname(elt, Trivial; cutoff)
-            U = basis_transform(symmetry; cutoff)
-            return symmetrize(O, U, boson_space(symmetry; cutoff))
-        end
-    end
 end
 
 end

--- a/src/bosonoperators.jl
+++ b/src/bosonoperators.jl
@@ -57,8 +57,7 @@ _symmetrize_operator(O::AbstractTensorMap, symmetry::Type{<:Sector}; kwargs...) 
 
 The truncated bosonic annihilation operator, with a maximum of `cutoff` bosons per site.
 """
-@operator b⁻ b_min(::Type{<:Number}, ::Type{<:Sector}; cutoff)
-function b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+@operator b⁻ function b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     pspace = boson_space(Trivial; cutoff)
     b⁻ = zeros(elt, pspace ← pspace)
     for i in 1:cutoff
@@ -73,8 +72,7 @@ end
 
 The truncated bosonic creation operator, with a maximum of `cutoff` bosons per site.
 """
-@operator b⁺ b_plus(::Type{<:Number}, ::Type{<:Sector}; cutoff)
-function b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+@operator b⁺ function b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     pspace = boson_space(Trivial; cutoff)
     b⁺ = zeros(elt, pspace ← pspace)
     for i in 1:cutoff
@@ -89,8 +87,7 @@ end
 
 The truncated bosonic number operator, with a maximum of `cutoff` bosons per site.
 """
-@operator n b_num(::Type{<:Number}, ::Type{<:Sector}; cutoff)
-function b_num(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+@operator n function b_num(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     pspace = boson_space(Trivial; cutoff)
     n = zeros(elt, pspace ← pspace)
     for i in 0:cutoff
@@ -107,8 +104,7 @@ end
 
 The truncated bosonic pair-creation operator, with a maximum of `cutoff` bosons per site.
 """
-@operator b⁺b⁺ b_plus_b_plus(::Type{<:Number}, ::Type{<:Sector}; cutoff)
-function b_plus_b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+@operator b⁺b⁺ function b_plus_b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     b⁺ = b_plus(elt, Trivial; cutoff)
     return b⁺ ⊗ b⁺
 end
@@ -119,8 +115,7 @@ end
 
 The truncated bosonic left-hopping operator, with a maximum of `cutoff` bosons per site.
 """
-@operator b⁺b⁻ b_plus_b_min(::Type{<:Number}, ::Type{<:Sector}; cutoff)
-function b_plus_b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+@operator b⁺b⁻ function b_plus_b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     b⁺ = b_plus(elt, Trivial; cutoff)
     b⁻ = b_min(elt, Trivial; cutoff)
     return b⁺ ⊗ b⁻
@@ -132,8 +127,7 @@ end
 
 The truncated bosonic right-hopping operator, with a maximum of `cutoff` bosons per site.
 """
-@operator b⁻b⁺ b_min_b_plus(::Type{<:Number}, ::Type{<:Sector}; cutoff)
-function b_min_b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+@operator b⁻b⁺ function b_min_b_plus(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     b⁺ = b_plus(elt, Trivial; cutoff)
     b⁻ = b_min(elt, Trivial; cutoff)
     return b⁻ ⊗ b⁺
@@ -145,8 +139,7 @@ end
 
 The truncated bosonic pair-annihilation operator, with a maximum of `cutoff` bosons per site.
 """
-@operator b⁻b⁻ b_min_b_min(::Type{<:Number}, ::Type{<:Sector}; cutoff)
-function b_min_b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+@operator b⁻b⁻ function b_min_b_min(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     b⁻ = b_min(elt, Trivial; cutoff)
     return b⁻ ⊗ b⁻
 end
@@ -157,8 +150,7 @@ end
 
 Return the two-body operator that describes a particle that hops between the first and the second site.
 """
-@operator b_hop b_hopping(::Type{<:Number}, ::Type{<:Sector}; cutoff)
-function b_hopping(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
+@operator b_hop function b_hopping(elt::Type{<:Number}, ::Type{Trivial}; cutoff::Integer)
     return b_plus_b_min(elt, Trivial; cutoff) + b_min_b_plus(elt, Trivial; cutoff)
 end
 

--- a/src/fermionoperators.jl
+++ b/src/fermionoperators.jl
@@ -2,7 +2,7 @@ module FermionOperators
 
 using TensorKit
 using LinearAlgebra: I
-import ..TensorKitTensors: symmetrize, desymmetrize
+import ..TensorKitTensors: symmetrize, desymmetrize, @operator
 
 export fermion_space, basis_transform
 export f_num
@@ -43,116 +43,102 @@ function basis_transform(symmetry::Type{<:Sector})
     return TensorMap(Matrix{Int}(I, 2, 2), V ← desymmetrize(fermion_space(Trivial)))
 end
 
+# Symmetrize a fermion operator through its basis transformation
+_symmetrize_operator(O::AbstractTensorMap, symmetry::Type{<:Sector}) =
+    symmetrize(O, basis_transform(symmetry), fermion_space(symmetry))
+
 # Single-site operators
 # ---------------------
-function single_site_operator(T::Type{<:Number}, symmetry::Type{<:Sector} = Trivial)
+function single_site_operator(T::Type{<:Number}, symmetry::Type{<:Sector})
     V = fermion_space(symmetry)
     return zeros(T, V ← V)
 end
 
-@doc """
+"""
     f_num([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
     n([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
 
 Return the one-body operator that counts the nunber of particles.
-""" f_num
+"""
+@operator n f_num(::Type{<:Number}, ::Type{<:Sector})
 function f_num(T::Type{<:Number}, ::Type{Trivial})
     t = single_site_operator(T, Trivial)
     block(t, fℤ₂(1)) .= one(T)
     return t
 end
-const n = f_num
 
 # Two site operators
 # ------------------
-function two_site_operator(T::Type{<:Number}, symmetry::Type{<:Sector} = Trivial)
+function two_site_operator(T::Type{<:Number}, symmetry::Type{<:Sector})
     V = fermion_space(symmetry)
     return zeros(T, V ⊗ V ← V ⊗ V)
 end
 
-@doc """
+"""
     f_plus_f_min([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
     f⁺f⁻([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
 
 Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
-""" f_plus_f_min
+"""
+@operator f⁺f⁻ f_plus_f_min(::Type{<:Number}, ::Type{<:Sector})
 function f_plus_f_min(T::Type{<:Number}, ::Type{Trivial})
     t = two_site_operator(T, Trivial)
     I = sectortype(t)
     t[(I(1), I(0), dual(I(0)), dual(I(1)))] .= 1
     return t
 end
-const f⁺f⁻ = f_plus_f_min
 
-@doc """
+"""
     f_min_f_plus([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
     f⁻f⁺([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
 
 Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
-""" f_min_f_plus
+"""
+@operator f⁻f⁺ f_min_f_plus(::Type{<:Number}, ::Type{<:Sector})
 function f_min_f_plus(T::Type{<:Number}, ::Type{Trivial})
     t = two_site_operator(T, Trivial)
     I = sectortype(t)
     t[(I(0), I(1), dual(I(1)), dual(I(0)))] .= -1
     return t
 end
-const f⁻f⁺ = f_min_f_plus
 
-@doc """
+"""
     f_plus_f_plus([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
     f⁺f⁺([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
 
 Return the two-body operator that creates a particle at the first and at the second site. It only has `Trivial` symmetry.
-""" f_plus_f_plus
+"""
+@operator f⁺f⁺ f_plus_f_plus(::Type{<:Number}, ::Type{<:Sector})
 function f_plus_f_plus(T::Type{<:Number}, ::Type{Trivial})
     t = two_site_operator(T, Trivial)
     I = sectortype(t)
     t[(I(1), I(1), dual(I(0)), dual(I(0)))] .= 1
     return t
 end
-const f⁺f⁺ = f_plus_f_plus
 
-@doc """
+"""
     f_min_f_min([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
     f⁻f⁻([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
 
 Return the two-body operator that annihilates a particle at the first and at the second site. It only has `Trivial` symmetry.
-""" f_min_f_min
+"""
+@operator f⁻f⁻ f_min_f_min(::Type{<:Number}, ::Type{<:Sector})
 function f_min_f_min(T::Type{<:Number}, ::Type{Trivial})
     t = two_site_operator(T, Trivial)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))] .= -1
     return t
 end
-const f⁻f⁻ = f_min_f_min
 
-@doc """
+"""
     f_hopping([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
     f_hop([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial])
 
 Return the two-body operator that describes a particle that hops between the first and the second site.
-""" f_hopping
+"""
+@operator f_hop f_hopping(::Type{<:Number}, ::Type{<:Sector})
 function f_hopping(elt::Type{<:Number}, ::Type{Trivial})
     return f_plus_f_min(elt, Trivial) - f_min_f_plus(elt, Trivial)
-end
-const f_hop = f_hopping
-
-# Symmetric operators and default arguments
-# -----------------------------------------
-# The symmetric operators are automatically generated from their `Trivial` counterparts
-# through `symmetrize` and `basis_transform`. Operators that are incompatible with a given
-# symmetry throw an `ArgumentError`.
-for opname in (:f_num, :f_plus_f_min, :f_min_f_plus, :f_plus_f_plus, :f_min_f_min, :f_hopping)
-    @eval begin
-        $opname() = $opname(ComplexF64, Trivial)
-        $opname(elt::Type{<:Number}) = $opname(elt, Trivial)
-        $opname(symmetry::Type{<:Sector}) = $opname(ComplexF64, symmetry)
-        function $opname(elt::Type{<:Number}, symmetry::Type{<:Sector})
-            O = $opname(elt, Trivial)
-            U = basis_transform(symmetry)
-            return symmetrize(O, U, fermion_space(symmetry))
-        end
-    end
 end
 
 end

--- a/src/fermionoperators.jl
+++ b/src/fermionoperators.jl
@@ -60,8 +60,7 @@ end
 
 Return the one-body operator that counts the nunber of particles.
 """
-@operator n f_num(::Type{<:Number}, ::Type{<:Sector})
-function f_num(T::Type{<:Number}, ::Type{Trivial})
+@operator n function f_num(T::Type{<:Number}, ::Type{Trivial})
     t = single_site_operator(T, Trivial)
     block(t, fℤ₂(1)) .= one(T)
     return t
@@ -80,8 +79,7 @@ end
 
 Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
 """
-@operator f⁺f⁻ f_plus_f_min(::Type{<:Number}, ::Type{<:Sector})
-function f_plus_f_min(T::Type{<:Number}, ::Type{Trivial})
+@operator f⁺f⁻ function f_plus_f_min(T::Type{<:Number}, ::Type{Trivial})
     t = two_site_operator(T, Trivial)
     I = sectortype(t)
     t[(I(1), I(0), dual(I(0)), dual(I(1)))] .= 1
@@ -94,8 +92,7 @@ end
 
 Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
 """
-@operator f⁻f⁺ f_min_f_plus(::Type{<:Number}, ::Type{<:Sector})
-function f_min_f_plus(T::Type{<:Number}, ::Type{Trivial})
+@operator f⁻f⁺ function f_min_f_plus(T::Type{<:Number}, ::Type{Trivial})
     t = two_site_operator(T, Trivial)
     I = sectortype(t)
     t[(I(0), I(1), dual(I(1)), dual(I(0)))] .= -1
@@ -108,8 +105,7 @@ end
 
 Return the two-body operator that creates a particle at the first and at the second site. It only has `Trivial` symmetry.
 """
-@operator f⁺f⁺ f_plus_f_plus(::Type{<:Number}, ::Type{<:Sector})
-function f_plus_f_plus(T::Type{<:Number}, ::Type{Trivial})
+@operator f⁺f⁺ function f_plus_f_plus(T::Type{<:Number}, ::Type{Trivial})
     t = two_site_operator(T, Trivial)
     I = sectortype(t)
     t[(I(1), I(1), dual(I(0)), dual(I(0)))] .= 1
@@ -122,8 +118,7 @@ end
 
 Return the two-body operator that annihilates a particle at the first and at the second site. It only has `Trivial` symmetry.
 """
-@operator f⁻f⁻ f_min_f_min(::Type{<:Number}, ::Type{<:Sector})
-function f_min_f_min(T::Type{<:Number}, ::Type{Trivial})
+@operator f⁻f⁻ function f_min_f_min(T::Type{<:Number}, ::Type{Trivial})
     t = two_site_operator(T, Trivial)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))] .= -1
@@ -136,8 +131,7 @@ end
 
 Return the two-body operator that describes a particle that hops between the first and the second site.
 """
-@operator f_hop f_hopping(::Type{<:Number}, ::Type{<:Sector})
-function f_hopping(elt::Type{<:Number}, ::Type{Trivial})
+@operator f_hop function f_hopping(elt::Type{<:Number}, ::Type{Trivial})
     return f_plus_f_min(elt, Trivial) - f_min_f_plus(elt, Trivial)
 end
 

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -23,7 +23,7 @@ export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
 export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
 export singlet⁺, singlet⁻
-export S⁻S⁺, S⁺S⁻
+export S⁻S⁺, S⁺S⁻, SS
 
 """
     hubbard_space(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
@@ -193,8 +193,7 @@ end
 
 Return the one-body operator that counts the number of spin-up particles.
 """
-@operator nꜛ u_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator nꜛ function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(1), elt)
     I = sectortype(t)
     t[(I(1), I(1))][1, 1] = 1
@@ -208,8 +207,7 @@ end
 
 Return the one-body operator that counts the number of spin-down particles.
 """
-@operator nꜜ d_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator nꜜ function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(1), elt)
     I = sectortype(t)
     t[(I(1), I(1))][2, 2] = 1
@@ -223,8 +221,7 @@ end
 
 Return the one-body operator that counts the number of particles.
 """
-@operator n e_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator n function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return u_num(elt, Trivial, Trivial) + d_num(elt, Trivial, Trivial)
 end
 
@@ -234,8 +231,7 @@ end
 
 Return the one-body operator that counts the number of doubly occupied sites.
 """
-@operator nꜛꜜ ud_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator nꜛꜜ function ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return u_num(elt, Trivial, Trivial) * d_num(elt, Trivial, Trivial)
 end
 
@@ -244,8 +240,7 @@ end
 
 Return the the one-body operator that is equivalent to `(nꜛ - 1/2)(nꜜ - 1/2)`, which respects the particle-hole symmetry.
 """
-@operator half_ud_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function half_ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator function half_ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     I = id(hubbard_space(Trivial, Trivial))
     return (u_num(elt, Trivial, Trivial) - I / 2) * (d_num(elt, Trivial, Trivial) - I / 2)
 end
@@ -256,8 +251,7 @@ end
 
 Return the one-body operator that counts the number of holes, i.e. the number of non-occupied sites.
 """
-@operator nʰ h_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function h_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator nʰ function h_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return id(elt, hubbard_space(Trivial, Trivial)) - e_num(elt, Trivial, Trivial)
 end
 
@@ -267,8 +261,7 @@ end
 
 Return the spin-plus operator `S⁺ = e†_↑ e_↓` (only compatible with `Trivial` spin symmetry).
 """
-@operator S⁺ S_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator S⁺ function S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(1), elt)
     I = sectortype(t)
     t[(I(1), dual(I(1)))][1, 2] = 1.0
@@ -281,8 +274,7 @@ end
 
 Return the spin-minus operator `S⁻ = e†_↓ e_↑` (only compatible with `Trivial` spin symmetry).
 """
-@operator S⁻ S_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator S⁻ function S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return copy(adjoint(S_plus(elt, Trivial, Trivial)))
 end
 
@@ -292,8 +284,7 @@ end
 
 Return the one-body spin-1/2 x-operator on the electrons (only compatible with `Trivial` spin symmetry).
 """
-@operator Sˣ S_x(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function S_x(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator Sˣ function S_x(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return (S_plus(elt, Trivial, Trivial) + S_min(elt, Trivial, Trivial)) / 2
 end
 
@@ -303,8 +294,7 @@ end
 
 Return the one-body spin-1/2 y-operator on the electrons (only compatible with `Trivial` spin symmetry).
 """
-@operator Sʸ S_y(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function S_y(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator Sʸ function S_y(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     # explicit error to avoid infinite recursion:
     elt <: Real && throw(ArgumentError("S_y requires `elt <: Complex`"))
     return (S_plus(elt, Trivial, Trivial) - S_min(elt, Trivial, Trivial)) / (2im)
@@ -316,8 +306,7 @@ end
 
 Return the one-body spin-1/2 z-operator on the electrons.
 """
-@operator Sᶻ S_z(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator Sᶻ function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return (u_num(elt, Trivial, Trivial) - d_num(elt, Trivial, Trivial)) / 2
 end
 
@@ -329,8 +318,7 @@ end
 
 Return the two-body operator ``e†_{1,↑}, e_{2,↑}`` that creates a spin-up particle at the first site and annihilates a spin-up particle at the second.
 """
-@operator u⁺u⁻ u_plus_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator u⁺u⁻ function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
     t[(I(1), I(0), dual(I(0)), dual(I(1)))][1, 1, 1, 1] = 1
@@ -346,8 +334,7 @@ end
 
 Return the two-body operator ``e†_{1,↓}, e_{2,↓}`` that creates a spin-down particle at the first site and annihilates a spin-down particle at the second.
 """
-@operator d⁺d⁻ d_plus_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator d⁺d⁻ function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
     t[(I(1), I(0), dual(I(0)), dual(I(1)))][2, 1, 1, 2] = 1
@@ -363,8 +350,7 @@ end
 
 Return the two-body operator ``e_{1,↑}, e†_{2,↑}`` that annihilates a spin-up particle at the first site and creates a spin-up particle at the second.
 """
-@operator u⁻u⁺ u_min_u_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function u_min_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator u⁻u⁺ function u_min_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(u_plus_u_min(elt, Trivial, Trivial)))
 end
 
@@ -374,8 +360,7 @@ end
 
 Return the two-body operator ``e_{1,↓}, e†_{2,↓}`` that annihilates a spin-down particle at the first site and creates a spin-down particle at the second.
 """
-@operator d⁻d⁺ d_min_d_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function d_min_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator d⁻d⁺ function d_min_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(d_plus_d_min(elt, Trivial, Trivial)))
 end
 
@@ -386,8 +371,7 @@ end
 Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
 This is the sum of `u_plus_u_min` and `d_plus_d_min`.
 """
-@operator e⁺e⁻ e_plus_e_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator e⁺e⁻ function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return u_plus_u_min(elt, Trivial, Trivial) + d_plus_d_min(elt, Trivial, Trivial)
 end
 
@@ -398,8 +382,7 @@ end
 Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
 This is the sum of `u_min_u_plus` and `d_min_d_plus`.
 """
-@operator e⁻e⁺ e_min_e_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function e_min_e_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator e⁻e⁺ function e_min_e_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(e_plus_e_min(elt, Trivial, Trivial)))
 end
 
@@ -413,8 +396,7 @@ For `SU2Irrep` particle symmetry, the hopping operator is expressed in the stagg
 ``c_{j,σ} → i^j c_{j,σ}`` and requires a complex scalar type; see
 [`basis_transform`](@ref HubbardOperators.basis_transform) for details.
 """
-@operator e_hop e_hopping(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function e_hopping(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator e_hop function e_hopping(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return e_plus_e_min(elt, Trivial, Trivial) - e_min_e_plus(elt, Trivial, Trivial)
 end
 
@@ -429,8 +411,7 @@ The nonzero matrix elements are
     +|↓,0⟩ ↤ |↑↓,↓⟩,    -|↓,↑⟩ ↤ |↑↓,↑↓⟩
 ```
 """
-@operator u⁻d⁻ u_min_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator u⁻d⁻ function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 2] = -1
@@ -446,8 +427,7 @@ end
 
 Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that creates a spin-up particle at the first site and a spin-down particle at the second site.
 """
-@operator u⁺d⁺ u_plus_d_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function u_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator u⁺d⁺ function u_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(u_min_d_min(elt, Trivial, Trivial)))
 end
 
@@ -462,8 +442,7 @@ The nonzero matrix elements are
     -|↑,0⟩ ↤ |↑↓,↑⟩,    -|↑,↓⟩ ↤ |↑↓,↑↓⟩
 ```
 """
-@operator d⁻u⁻ d_min_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator d⁻u⁻ function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 1] = -1
@@ -479,8 +458,7 @@ end
 
 Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down particle at the first site and a spin-up particle at the second site.
 """
-@operator d⁺u⁺ d_plus_u_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function d_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator d⁺u⁺ function d_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(d_min_u_min(elt, Trivial, Trivial)))
 end
 
@@ -495,8 +473,7 @@ The nonzero matrix elements are
     +|↓,0⟩ ↤ |↑↓,↑⟩,    +|↓,↓⟩ ↤ |↑↓,↑↓⟩
 ```
 """
-@operator u⁻u⁻ u_min_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator u⁻u⁻ function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 1] = -1
@@ -512,8 +489,7 @@ end
 
 Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up particle at both sites.
 """
-@operator u⁺u⁺ u_plus_u_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function u_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator u⁺u⁺ function u_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(u_min_u_min(elt, Trivial, Trivial)))
 end
 
@@ -528,8 +504,7 @@ The nonzero matrix elements are
     -|↑,0⟩ ↤ |↑↓,↓⟩,    +|↑,↑⟩ ↤ |↑↓,↑↓⟩
 ```
 """
-@operator d⁻d⁻ d_min_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator d⁻d⁻ function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
     t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 2] = -1
@@ -545,8 +520,7 @@ end
 
 Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down particle at both sites.
 """
-@operator d⁺d⁺ d_plus_d_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function d_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator d⁺d⁺ function d_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(d_min_d_min(elt, Trivial, Trivial)))
 end
 
@@ -557,8 +531,7 @@ end
 Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``,
 which creates the singlet state when acting on vaccum.
 """
-@operator singlet⁺ singlet_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function singlet_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator singlet⁺ function singlet_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return (u_plus_d_plus(elt, Trivial, Trivial) - d_plus_u_plus(elt, Trivial, Trivial)) /
         sqrt(2)
 end
@@ -570,8 +543,7 @@ end
 Return the adjoint of `singlet_plus` operator, which is
 ``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / \\sqrt{2}``.
 """
-@operator singlet⁻ singlet_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function singlet_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator singlet⁻ function singlet_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return copy(adjoint(singlet_plus(elt, Trivial, Trivial)))
 end
 
@@ -582,8 +554,7 @@ end
 Return the two-body operator S⁺S⁻.
 The only nonzero matrix element corresponds to `|↑,↓⟩ <-- |↓,↑⟩`.
 """
-@operator S⁺S⁻ S_plus_S_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator S⁺S⁻ function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
     t[(I(1), I(1), dual(I(1)), dual(I(1)))][1, 2, 2, 1] = 1
@@ -597,8 +568,7 @@ end
 Return the two-body operator S⁻S⁺.
 The only nonzero matrix element corresponds to `|↓,↑⟩ <-- |↑,↓⟩`.
 """
-@operator S⁻S⁺ S_min_S_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function S_min_S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator S⁻S⁺ function S_min_S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return copy(adjoint(S_plus_S_min(elt, Trivial, Trivial)))
 end
 
@@ -607,8 +577,7 @@ end
 
 Return the spin exchange operator S⋅S.
 """
-@operator S_exchange(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
-function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
+@operator SS function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     Sz = S_z(elt, Trivial, Trivial)
     return Sz ⊗ Sz +
         (S_plus_S_min(elt, Trivial, Trivial) + S_min_S_plus(elt, Trivial, Trivial)) / 2

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -1,7 +1,7 @@
 module HubbardOperators
 
 using TensorKit
-import ..TensorKitTensors: symmetrize, desymmetrize
+import ..TensorKitTensors: symmetrize, desymmetrize, @operator
 
 export hubbard_space, basis_transform
 export e_num, u_num, d_num, ud_num, half_ud_num, h_num
@@ -176,6 +176,10 @@ function _symmetrize_hubbard(
     return symmetrize(O, map(g -> U * g, Gs), V)
 end
 
+# Symmetrize a Hubbard operator through its (staggered-gauge) basis transformation
+_symmetrize_operator(O::AbstractTensorMap, P::Type{<:Sector}, S::Type{<:Sector}) =
+    _symmetrize_hubbard(O, P, S)
+
 function n_site_operator(::Val{N}, elt::Type{<:Number}) where {N}
     V = hubbard_space(Trivial, Trivial)
     return zeros(elt, V^N ← V^N)
@@ -183,12 +187,13 @@ end
 
 # Single-site operators
 # ---------------------
-@doc """
+"""
     u_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     nꜛ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of spin-up particles.
-""" u_num
+"""
+@operator nꜛ u_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(1), elt)
     I = sectortype(t)
@@ -196,14 +201,14 @@ function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(0), I(0))][2, 2] = 1
     return t
 end
-const nꜛ = u_num
 
-@doc """
+"""
     d_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     nꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of spin-down particles.
-""" d_num
+"""
+@operator nꜜ d_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(1), elt)
     I = sectortype(t)
@@ -211,119 +216,120 @@ function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(0), I(0))][2, 2] = 1
     return t
 end
-const nꜜ = d_num
 
-@doc """
+"""
     e_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     n([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of particles.
-""" e_num
+"""
+@operator n e_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return u_num(elt, Trivial, Trivial) + d_num(elt, Trivial, Trivial)
 end
-const n = e_num
 
-@doc """
+"""
     ud_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     nꜛꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of doubly occupied sites.
-""" ud_num
+"""
+@operator nꜛꜜ ud_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return u_num(elt, Trivial, Trivial) * d_num(elt, Trivial, Trivial)
 end
-const nꜛꜜ = ud_num
 
-@doc """
+"""
     half_ud_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the the one-body operator that is equivalent to `(nꜛ - 1/2)(nꜜ - 1/2)`, which respects the particle-hole symmetry.
-""" half_ud_num
+"""
+@operator half_ud_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function half_ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     I = id(hubbard_space(Trivial, Trivial))
     return (u_num(elt, Trivial, Trivial) - I / 2) * (d_num(elt, Trivial, Trivial) - I / 2)
 end
 
-@doc """
+"""
     h_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     nʰ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of holes, i.e. the number of non-occupied sites.
-""" h_num
+"""
+@operator nʰ h_num(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function h_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return id(elt, hubbard_space(Trivial, Trivial)) - e_num(elt, Trivial, Trivial)
 end
-const nʰ = h_num
 
-@doc """
+"""
     S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the spin-plus operator `S⁺ = e†_↑ e_↓` (only compatible with `Trivial` spin symmetry).
-""" S_plus
+"""
+@operator S⁺ S_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(1), elt)
     I = sectortype(t)
     t[(I(1), dual(I(1)))][1, 2] = 1.0
     return t
 end
-const S⁺ = S_plus
 
-@doc """
+"""
     S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the spin-minus operator `S⁻ = e†_↓ e_↑` (only compatible with `Trivial` spin symmetry).
-""" S_min
+"""
+@operator S⁻ S_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return copy(adjoint(S_plus(elt, Trivial, Trivial)))
 end
-const S⁻ = S_min
 
-@doc """
+"""
     S_x([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     Sˣ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body spin-1/2 x-operator on the electrons (only compatible with `Trivial` spin symmetry).
-""" S_x
+"""
+@operator Sˣ S_x(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function S_x(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return (S_plus(elt, Trivial, Trivial) + S_min(elt, Trivial, Trivial)) / 2
 end
-const Sˣ = S_x
 
-@doc """
+"""
     S_y([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     Sʸ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body spin-1/2 y-operator on the electrons (only compatible with `Trivial` spin symmetry).
-""" S_y
+"""
+@operator Sʸ S_y(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function S_y(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     # explicit error to avoid infinite recursion:
     elt <: Real && throw(ArgumentError("S_y requires `elt <: Complex`"))
     return (S_plus(elt, Trivial, Trivial) - S_min(elt, Trivial, Trivial)) / (2im)
 end
-const Sʸ = S_y
 
-@doc """
+"""
     S_z([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     Sᶻ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the one-body spin-1/2 z-operator on the electrons.
-""" S_z
+"""
+@operator Sᶻ S_z(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function S_z(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return (u_num(elt, Trivial, Trivial) - d_num(elt, Trivial, Trivial)) / 2
 end
-const Sᶻ = S_z
 
 # Two site operators
 # ------------------
-@doc """
+"""
     u_plus_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     u⁺u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↑}, e_{2,↑}`` that creates a spin-up particle at the first site and annihilates a spin-up particle at the second.
-""" u_plus_u_min
+"""
+@operator u⁺u⁻ u_plus_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
@@ -333,14 +339,14 @@ function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(0), I(1), dual(I(1)), dual(I(0)))][2, 2, 2, 2] = -1
     return t
 end
-const u⁺u⁻ = u_plus_u_min
 
-@doc """
+"""
     d_plus_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     d⁺d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↓}, e_{2,↓}`` that creates a spin-down particle at the first site and annihilates a spin-down particle at the second.
-""" d_plus_d_min
+"""
+@operator d⁺d⁻ d_plus_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
@@ -350,55 +356,54 @@ function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(0), I(1), dual(I(1)), dual(I(0)))][2, 1, 1, 2] = -1
     return t
 end
-const d⁺d⁻ = d_plus_d_min
 
-@doc """
+"""
     u_min_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     u⁻u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e_{1,↑}, e†_{2,↑}`` that annihilates a spin-up particle at the first site and creates a spin-up particle at the second.
-""" u_min_u_plus
+"""
+@operator u⁻u⁺ u_min_u_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function u_min_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(u_plus_u_min(elt, Trivial, Trivial)))
 end
-const u⁻u⁺ = u_min_u_plus
 
-@doc """
+"""
     d_min_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     d⁻d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e_{1,↓}, e†_{2,↓}`` that annihilates a spin-down particle at the first site and creates a spin-down particle at the second.
-""" d_min_d_plus
+"""
+@operator d⁻d⁺ d_min_d_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function d_min_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(d_plus_d_min(elt, Trivial, Trivial)))
 end
-const d⁻d⁺ = d_min_d_plus
 
-@doc """
+"""
     e_plus_e_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     e⁺e⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
 This is the sum of `u_plus_u_min` and `d_plus_d_min`.
-""" e_plus_e_min
+"""
+@operator e⁺e⁻ e_plus_e_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return u_plus_u_min(elt, Trivial, Trivial) + d_plus_d_min(elt, Trivial, Trivial)
 end
-const e⁺e⁻ = e_plus_e_min
 
-@doc """
+"""
     e_min_e_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     e⁻e⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
 This is the sum of `u_min_u_plus` and `d_min_d_plus`.
-""" e_min_e_plus
+"""
+@operator e⁻e⁺ e_min_e_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function e_min_e_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(e_plus_e_min(elt, Trivial, Trivial)))
 end
-const e⁻e⁺ = e_min_e_plus
 
-@doc """
+"""
     e_hopping([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     e_hop([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
@@ -407,13 +412,13 @@ Return the two-body operator that describes a particle that hops between the fir
 For `SU2Irrep` particle symmetry, the hopping operator is expressed in the staggered gauge
 ``c_{j,σ} → i^j c_{j,σ}`` and requires a complex scalar type; see
 [`basis_transform`](@ref HubbardOperators.basis_transform) for details.
-""" e_hopping
+"""
+@operator e_hop e_hopping(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function e_hopping(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return e_plus_e_min(elt, Trivial, Trivial) - e_min_e_plus(elt, Trivial, Trivial)
 end
-const e_hop = e_hopping
 
-@doc """
+"""
     u_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     u⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
@@ -423,7 +428,8 @@ The nonzero matrix elements are
     -|0,0⟩ ↤ |↑,↓⟩,     +|0,↑⟩ ↤ |↑,↑↓⟩,
     +|↓,0⟩ ↤ |↑↓,↓⟩,    -|↓,↑⟩ ↤ |↑↓,↑↓⟩
 ```
-""" u_min_d_min
+"""
+@operator u⁻d⁻ u_min_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
@@ -433,20 +439,19 @@ function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][2, 1, 2, 2] = -1
     return t
 end
-const u⁻d⁻ = u_min_d_min
 
-@doc """
+"""
     u_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     u⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that creates a spin-up particle at the first site and a spin-down particle at the second site.
-""" u_plus_d_plus
+"""
+@operator u⁺d⁺ u_plus_d_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function u_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(u_min_d_min(elt, Trivial, Trivial)))
 end
-const u⁺d⁺ = u_plus_d_plus
 
-@doc """
+"""
     d_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     d⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
@@ -456,7 +461,8 @@ The nonzero matrix elements are
     -|0,0⟩ ↤ |↓,↑⟩,     -|0,↓⟩ ↤ |↓,↑↓⟩
     -|↑,0⟩ ↤ |↑↓,↑⟩,    -|↑,↓⟩ ↤ |↑↓,↑↓⟩
 ```
-""" d_min_u_min
+"""
+@operator d⁻u⁻ d_min_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
@@ -466,20 +472,19 @@ function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][1, 2, 2, 2] = -1
     return t
 end
-const d⁻u⁻ = d_min_u_min
 
-@doc """
+"""
     d_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     d⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down particle at the first site and a spin-up particle at the second site.
-""" d_plus_u_plus
+"""
+@operator d⁺u⁺ d_plus_u_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function d_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(d_min_u_min(elt, Trivial, Trivial)))
 end
-const d⁺u⁺ = d_plus_u_plus
 
-@doc """
+"""
     u_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     u⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
@@ -489,7 +494,8 @@ The nonzero matrix elements are
     -|0,0⟩ ↤ |↑,↑⟩,     -|0,↓⟩ ↤ |↑,↑↓⟩
     +|↓,0⟩ ↤ |↑↓,↑⟩,    +|↓,↓⟩ ↤ |↑↓,↑↓⟩
 ```
-""" u_min_u_min
+"""
+@operator u⁻u⁻ u_min_u_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
@@ -499,20 +505,19 @@ function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][2, 2, 2, 2] = 1
     return t
 end
-const u⁻u⁻ = u_min_u_min
 
-@doc """
+"""
     u_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     u⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up particle at both sites.
-""" u_plus_u_plus
+"""
+@operator u⁺u⁺ u_plus_u_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function u_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(u_min_u_min(elt, Trivial, Trivial)))
 end
-const u⁺u⁺ = u_plus_u_plus
 
-@doc """
+"""
     d_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     d⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
@@ -522,7 +527,8 @@ The nonzero matrix elements are
     -|0,0⟩ ↤ |↓,↓⟩,     +|0,↑⟩ ↤ |↓,↑↓⟩
     -|↑,0⟩ ↤ |↑↓,↓⟩,    +|↑,↑⟩ ↤ |↑↓,↑↓⟩
 ```
-""" d_min_d_min
+"""
+@operator d⁻d⁻ d_min_d_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
@@ -532,111 +538,80 @@ function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t[(I(1), I(1), dual(I(0)), dual(I(0)))][1, 1, 2, 2] = 1
     return t
 end
-const d⁻d⁻ = d_min_d_min
 
-@doc """
+"""
     d_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     d⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down particle at both sites.
-""" d_plus_d_plus
+"""
+@operator d⁺d⁺ d_plus_d_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function d_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(d_min_d_min(elt, Trivial, Trivial)))
 end
-const d⁺d⁺ = d_plus_d_plus
 
-@doc """
+"""
     singlet_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     singlet⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``,
 which creates the singlet state when acting on vaccum.
-""" singlet_plus
+"""
+@operator singlet⁺ singlet_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function singlet_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return (u_plus_d_plus(elt, Trivial, Trivial) - d_plus_u_plus(elt, Trivial, Trivial)) /
         sqrt(2)
 end
-const singlet⁺ = singlet_plus
 
-@doc """
+"""
     singlet_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     singlet⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the adjoint of `singlet_plus` operator, which is
 ``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / \\sqrt{2}``.
-""" singlet_min
+"""
+@operator singlet⁻ singlet_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function singlet_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return copy(adjoint(singlet_plus(elt, Trivial, Trivial)))
 end
-const singlet⁻ = singlet_min
 
-@doc """
+"""
     S_plus_S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     S⁺S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator S⁺S⁻.
 The only nonzero matrix element corresponds to `|↑,↓⟩ <-- |↓,↑⟩`.
-""" S_plus_S_min
+"""
+@operator S⁺S⁻ S_plus_S_min(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
     I = sectortype(t)
     t[(I(1), I(1), dual(I(1)), dual(I(1)))][1, 2, 2, 1] = 1
     return t
 end
-const S⁺S⁻ = S_plus_S_min
 
-@doc """
+"""
     S_min_S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
     S⁻S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator S⁻S⁺.
 The only nonzero matrix element corresponds to `|↓,↑⟩ <-- |↑,↓⟩`.
-""" S_min_S_plus
+"""
+@operator S⁻S⁺ S_min_S_plus(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function S_min_S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return copy(adjoint(S_plus_S_min(elt, Trivial, Trivial)))
 end
-const S⁻S⁺ = S_min_S_plus
 
-@doc """
+"""
     S_exchange([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
 
 Return the spin exchange operator S⋅S.
-""" S_exchange
+"""
+@operator S_exchange(::Type{<:Number}, ::Type{<:Sector}, ::Type{<:Sector})
 function S_exchange(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     Sz = S_z(elt, Trivial, Trivial)
     return Sz ⊗ Sz +
         (S_plus_S_min(elt, Trivial, Trivial) + S_min_S_plus(elt, Trivial, Trivial)) / 2
-end
-
-# Symmetric operators and default arguments
-# -----------------------------------------
-# The symmetric operators are automatically generated from their `(Trivial, Trivial)`
-# counterparts through `symmetrize` and `basis_transform` (including the staggered gauge for
-# `SU2Irrep` particle symmetry). Operators that are incompatible with a given symmetry
-# combination throw an `ArgumentError`.
-for opname in (
-        :e_num, :u_num, :d_num, :ud_num, :half_ud_num, :h_num,
-        :S_x, :S_y, :S_z, :S_plus, :S_min,
-        :u_plus_u_min, :d_plus_d_min, :u_min_u_plus, :d_min_d_plus,
-        :u_min_d_min, :d_min_u_min, :u_plus_d_plus, :d_plus_u_plus,
-        :u_min_u_min, :d_min_d_min, :u_plus_u_plus, :d_plus_d_plus,
-        :e_plus_e_min, :e_min_e_plus, :e_hopping,
-        :singlet_plus, :singlet_min,
-        :S_plus_S_min, :S_min_S_plus, :S_exchange,
-    )
-    @eval begin
-        function $opname(P::Type{<:Sector} = Trivial, S::Type{<:Sector} = Trivial)
-            return $opname(ComplexF64, P, S)
-        end
-        $opname(elt::Type{<:Number}) = $opname(elt, Trivial, Trivial)
-        function $opname(
-                elt::Type{<:Number}, particle_symmetry::Type{<:Sector},
-                spin_symmetry::Type{<:Sector}
-            )
-            O = $opname(elt, Trivial, Trivial)
-            return _symmetrize_hubbard(O, particle_symmetry, spin_symmetry)
-        end
-    end
 end
 
 end

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -188,8 +188,8 @@ end
 # Single-site operators
 # ---------------------
 """
-    u_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    nꜛ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    nꜛ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of spin-up particles.
 """
@@ -203,8 +203,8 @@ function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    d_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    nꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    nꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of spin-down particles.
 """
@@ -218,8 +218,8 @@ function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    e_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    n([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    n([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of particles.
 """
@@ -229,8 +229,8 @@ function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    ud_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    nꜛꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    ud_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    nꜛꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of doubly occupied sites.
 """
@@ -240,7 +240,7 @@ function ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    half_ud_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    half_ud_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the the one-body operator that is equivalent to `(nꜛ - 1/2)(nꜜ - 1/2)`, which respects the particle-hole symmetry.
 """
@@ -251,8 +251,8 @@ function half_ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    h_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    nʰ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    h_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    nʰ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the one-body operator that counts the number of holes, i.e. the number of non-occupied sites.
 """
@@ -262,8 +262,8 @@ function h_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the spin-plus operator `S⁺ = e†_↑ e_↓` (only compatible with `Trivial` spin symmetry).
 """
@@ -276,8 +276,8 @@ function S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the spin-minus operator `S⁻ = e†_↓ e_↑` (only compatible with `Trivial` spin symmetry).
 """
@@ -287,8 +287,8 @@ function S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    S_x([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    Sˣ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    S_x([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    Sˣ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the one-body spin-1/2 x-operator on the electrons (only compatible with `Trivial` spin symmetry).
 """
@@ -298,8 +298,8 @@ function S_x(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    S_y([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    Sʸ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    S_y([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    Sʸ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the one-body spin-1/2 y-operator on the electrons (only compatible with `Trivial` spin symmetry).
 """
@@ -311,8 +311,8 @@ function S_y(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    S_z([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    Sᶻ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    S_z([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    Sᶻ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the one-body spin-1/2 z-operator on the electrons.
 """
@@ -324,8 +324,8 @@ end
 # Two site operators
 # ------------------
 """
-    u_plus_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    u⁺u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u_plus_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    u⁺u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↑}, e_{2,↑}`` that creates a spin-up particle at the first site and annihilates a spin-up particle at the second.
 """
@@ -341,8 +341,8 @@ function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    d_plus_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    d⁺d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d_plus_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    d⁺d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↓}, e_{2,↓}`` that creates a spin-down particle at the first site and annihilates a spin-down particle at the second.
 """
@@ -358,8 +358,8 @@ function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    u_min_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    u⁻u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u_min_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    u⁻u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e_{1,↑}, e†_{2,↑}`` that annihilates a spin-up particle at the first site and creates a spin-up particle at the second.
 """
@@ -369,8 +369,8 @@ function u_min_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    d_min_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    d⁻d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d_min_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    d⁻d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e_{1,↓}, e†_{2,↓}`` that annihilates a spin-down particle at the first site and creates a spin-down particle at the second.
 """
@@ -380,8 +380,8 @@ function d_min_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    e_plus_e_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    e⁺e⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e_plus_e_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    e⁺e⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
 This is the sum of `u_plus_u_min` and `d_plus_d_min`.
@@ -392,8 +392,8 @@ function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    e_min_e_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    e⁻e⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e_min_e_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    e⁻e⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
 This is the sum of `u_min_u_plus` and `d_min_d_plus`.
@@ -404,8 +404,8 @@ function e_min_e_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    e_hopping([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    e_hop([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    e_hopping([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    e_hop([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator that describes a particle that hops between the first and the second site.
 
@@ -419,8 +419,8 @@ function e_hopping(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    u_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    u⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    u⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up particle at the first site and a spin-down particle at the second site.
 The nonzero matrix elements are
@@ -441,8 +441,8 @@ function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    u_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    u⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    u⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that creates a spin-up particle at the first site and a spin-down particle at the second site.
 """
@@ -452,8 +452,8 @@ function u_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    d_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    d⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    d⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down particle at the first site and a spin-up particle at the second site.
 The nonzero matrix elements are
@@ -474,8 +474,8 @@ function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    d_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    d⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    d⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down particle at the first site and a spin-up particle at the second site.
 """
@@ -485,8 +485,8 @@ function d_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    u_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    u⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    u⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e_{1,↑} e_{2,↑}`` that annihilates a spin-up particle at both sites.
 The nonzero matrix elements are
@@ -507,8 +507,8 @@ function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    u_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    u⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    u_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    u⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up particle at both sites.
 """
@@ -518,8 +518,8 @@ function u_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    d_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    d⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    d⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e_{1,↓} e_{2,↓}`` that annihilates a spin-down particle at both sites.
 The nonzero matrix elements are
@@ -540,8 +540,8 @@ function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    d_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    d⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    d_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    d⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down particle at both sites.
 """
@@ -551,8 +551,8 @@ function d_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    singlet_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    singlet⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    singlet_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    singlet⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``,
 which creates the singlet state when acting on vaccum.
@@ -564,8 +564,8 @@ function singlet_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    singlet_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    singlet⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    singlet_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    singlet⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the adjoint of `singlet_plus` operator, which is
 ``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / \\sqrt{2}``.
@@ -576,8 +576,8 @@ function singlet_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    S_plus_S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    S⁺S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    S_plus_S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    S⁺S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator S⁺S⁻.
 The only nonzero matrix element corresponds to `|↑,↓⟩ <-- |↓,↑⟩`.
@@ -591,8 +591,8 @@ function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    S_min_S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
-    S⁻S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    S_min_S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    S⁻S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body operator S⁻S⁺.
 The only nonzero matrix element corresponds to `|↓,↑⟩ <-- |↑,↓⟩`.
@@ -603,7 +603,7 @@ function S_min_S_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
 end
 
 """
-    S_exchange([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}], [spin_symmetry::Type{<:Sector}])
+    S_exchange([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the spin exchange operator S⋅S.
 """

--- a/src/spinoperators.jl
+++ b/src/spinoperators.jl
@@ -152,8 +152,7 @@ Compatible symmetries: `Trivial`, `Z2Irrep`.
 
 See also [`σˣ`](@ref) (Pauli version ``\\sigma^x = 2S^x``).
 """
-@operator Sˣ S_x(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_x(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator Sˣ function S_x(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     S_x_mat, = spinmatrices(spin, elt)
     pspace = spin_space(Trivial; spin)
     return TensorMap(S_x_mat, pspace ← pspace)
@@ -180,8 +179,7 @@ Compatible symmetries: `Trivial`.
 
 See also [`σʸ`](@ref) (Pauli version ``\\sigma^y = 2S^y``).
 """
-@operator Sʸ S_y(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_y(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator Sʸ function S_y(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     # explicit error to avoid infinite recursion:
     elt <: Real && throw(ArgumentError("S_y requires `elt <: Complex`"))
     _, S_y_mat, _ = spinmatrices(spin, elt)
@@ -211,8 +209,7 @@ Compatible symmetries: `Trivial`, `U1Irrep`.
 
 See also [`σᶻ`](@ref) (Pauli version ``\\sigma^z = 2S^z``).
 """
-@operator Sᶻ S_z(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_z(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator Sᶻ function S_z(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     _, _, S_z_mat = spinmatrices(spin, elt)
     pspace = spin_space(Trivial; spin)
     return TensorMap(S_z_mat, pspace ← pspace)
@@ -240,8 +237,7 @@ Compatible symmetries: `Trivial`.
 
 See also [`σ⁺`](@ref) (Pauli version ``\\sigma^+ = 2S^+``).
 """
-@operator S⁺ S_plus(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_plus(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator S⁺ function S_plus(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     S⁺ = S_x(elt, Trivial; spin) + 1im * S_y(complex(elt), Trivial; spin)
     if elt <: Real
         S⁺ = real(S⁺)
@@ -271,8 +267,7 @@ Compatible symmetries: `Trivial`.
 
 See also [`σ⁻`](@ref) (Pauli version ``\\sigma^- = 2S^-``).
 """
-@operator S⁻ S_min(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_min(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator S⁻ function S_min(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     S⁻ = S_x(elt, Trivial; spin) - 1im * S_y(complex(elt), Trivial; spin)
     if elt <: Real
         S⁻ = real(S⁻)
@@ -301,8 +296,7 @@ The two-site operator ``S^x \\otimes S^x``.
 
 Compatible symmetries: `Trivial`, `Z2Irrep`.
 """
-@operator SˣSˣ S_x_S_x(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_x_S_x(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator SˣSˣ function S_x_S_x(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return S_x(elt, Trivial; spin) ⊗ S_x(elt, Trivial; spin)
 end
 
@@ -314,8 +308,7 @@ The two-site operator ``S^y \\otimes S^y``.
 
 Compatible symmetries: `Trivial`, `Z2Irrep`.
 """
-@operator SʸSʸ S_y_S_y(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_y_S_y(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator SʸSʸ function S_y_S_y(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     YY = S_y(complex(elt), Trivial; spin) ⊗ S_y(complex(elt), Trivial; spin)
     return elt <: Real ? real(YY) : YY
 end
@@ -328,8 +321,7 @@ The two-site operator ``S^z \\otimes S^z``.
 
 Compatible symmetries: `Trivial`, `U1Irrep`, `Z2Irrep`.
 """
-@operator SᶻSᶻ S_z_S_z(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_z_S_z(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator SᶻSᶻ function S_z_S_z(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return S_z(elt, Trivial; spin) ⊗ S_z(elt, Trivial; spin)
 end
 
@@ -341,8 +333,7 @@ The two-site operator ``S^+ \\otimes S^-``.
 
 Compatible symmetries: `Trivial`, `U1Irrep`.
 """
-@operator S⁺S⁻ S_plus_S_min(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator S⁺S⁻ function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return S_plus(elt, Trivial; spin) ⊗ S_min(elt, Trivial; spin)
 end
 
@@ -354,8 +345,7 @@ The two-site operator ``S^- \\otimes S^+``.
 
 Compatible symmetries: `Trivial`, `U1Irrep`.
 """
-@operator S⁻S⁺ S_min_S_plus(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_min_S_plus(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator S⁻S⁺ function S_min_S_plus(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return S_min(elt, Trivial; spin) ⊗ S_plus(elt, Trivial; spin)
 end
 
@@ -375,8 +365,7 @@ For `SU2Irrep` the operator is diagonal in the total-spin basis with eigenvalue
 
 Compatible symmetries: `Trivial`, `U1Irrep`, `Z2Irrep`, `SU2Irrep`.
 """
-@operator SS S_exchange(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_exchange(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator SS function S_exchange(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return (S_plus_S_min(elt, Trivial; spin) + S_min_S_plus(elt, Trivial; spin)) / 2 +
         S_z_S_z(elt, Trivial; spin)
 end

--- a/src/spinoperators.jl
+++ b/src/spinoperators.jl
@@ -3,7 +3,7 @@ module SpinOperators
 using TensorKit
 using LinearAlgebra: I
 using RationalRoots: signedroot
-import ..TensorKitTensors: symmetrize, desymmetrize
+import ..TensorKitTensors: symmetrize, desymmetrize, @operator
 
 export spin_space, basis_transform, casimir
 export S_x, S_y, S_z, S_plus, S_min
@@ -85,6 +85,10 @@ function basis_transform(::Type{SU2Irrep}; spin = 1 // 2)
     return TensorMap(Matrix{Int}(I, d, d), desymmetrize(spin_space(SU2Irrep; spin)) ← V)
 end
 
+# Symmetrize a spin operator through its basis transformation
+_symmetrize_operator(O::AbstractTensorMap, symmetry::Type{<:Sector}; kwargs...) =
+    symmetrize(O, basis_transform(symmetry; kwargs...), spin_space(symmetry; kwargs...))
+
 # Pauli matrices
 # --------------
 function _pauliterm(spin, i, j)
@@ -138,7 +142,7 @@ end
 
 # Single-site operators
 # ---------------------
-@doc """
+"""
     S_x([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     Sˣ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
@@ -147,13 +151,13 @@ The spin-x operator ``S^x = \\tfrac{1}{2}(S^+ + S^-)``.
 Compatible symmetries: `Trivial`, `Z2Irrep`.
 
 See also [`σˣ`](@ref) (Pauli version ``\\sigma^x = 2S^x``).
-""" S_x
+"""
+@operator Sˣ S_x(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_x(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     S_x_mat, = spinmatrices(spin, elt)
     pspace = spin_space(Trivial; spin)
     return TensorMap(S_x_mat, pspace ← pspace)
 end
-const Sˣ = S_x
 
 @doc """
     σˣ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
@@ -166,7 +170,7 @@ See also [`S_x`](@ref).
 """ σˣ
 σˣ(args...; kwargs...) = 2 * S_x(args...; kwargs...)
 
-@doc """
+"""
     S_y([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     Sʸ([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
@@ -175,7 +179,8 @@ The spin-y operator ``S^y = \\tfrac{1}{2i}(S^+ - S^-)``.
 Compatible symmetries: `Trivial`.
 
 See also [`σʸ`](@ref) (Pauli version ``\\sigma^y = 2S^y``).
-""" S_y
+"""
+@operator Sʸ S_y(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_y(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     # explicit error to avoid infinite recursion:
     elt <: Real && throw(ArgumentError("S_y requires `elt <: Complex`"))
@@ -183,7 +188,6 @@ function S_y(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     pspace = spin_space(Trivial; spin)
     return TensorMap(S_y_mat, pspace ← pspace)
 end
-const Sʸ = S_y
 
 @doc """
     σʸ([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
@@ -196,7 +200,7 @@ See also [`S_y`](@ref).
 """ σʸ
 σʸ(args...; kwargs...) = 2 * S_y(args...; kwargs...)
 
-@doc """
+"""
     S_z([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     Sᶻ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
@@ -206,13 +210,13 @@ The spin-z operator, diagonal in the standard basis with eigenvalues
 Compatible symmetries: `Trivial`, `U1Irrep`.
 
 See also [`σᶻ`](@ref) (Pauli version ``\\sigma^z = 2S^z``).
-""" S_z
+"""
+@operator Sᶻ S_z(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_z(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     _, _, S_z_mat = spinmatrices(spin, elt)
     pspace = spin_space(Trivial; spin)
     return TensorMap(S_z_mat, pspace ← pspace)
 end
-const Sᶻ = S_z
 
 @doc """
     σᶻ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
@@ -225,7 +229,7 @@ See also [`S_z`](@ref).
 """ σᶻ
 σᶻ(args...; kwargs...) = 2 * S_z(args...; kwargs...)
 
-@doc """
+"""
     S_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     S⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
@@ -235,7 +239,8 @@ The spin raising operator ``S^+ = S^x + iS^y``, with matrix elements
 Compatible symmetries: `Trivial`.
 
 See also [`σ⁺`](@ref) (Pauli version ``\\sigma^+ = 2S^+``).
-""" S_plus
+"""
+@operator S⁺ S_plus(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_plus(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     S⁺ = S_x(elt, Trivial; spin) + 1im * S_y(complex(elt), Trivial; spin)
     if elt <: Real
@@ -243,7 +248,6 @@ function S_plus(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     end
     return S⁺
 end
-const S⁺ = S_plus
 
 @doc """
     σ⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
@@ -256,7 +260,7 @@ See also [`S_plus`](@ref).
 """ σ⁺
 σ⁺(args...; kwargs...) = 2 * S_plus(args...; kwargs...)
 
-@doc """
+"""
     S_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     S⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
@@ -266,7 +270,8 @@ The spin lowering operator ``S^- = S^x - iS^y``, with matrix elements
 Compatible symmetries: `Trivial`.
 
 See also [`σ⁻`](@ref) (Pauli version ``\\sigma^- = 2S^-``).
-""" S_min
+"""
+@operator S⁻ S_min(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_min(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     S⁻ = S_x(elt, Trivial; spin) - 1im * S_y(complex(elt), Trivial; spin)
     if elt <: Real
@@ -274,7 +279,6 @@ function S_min(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     end
     return S⁻
 end
-const S⁻ = S_min
 
 @doc """
     σ⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
@@ -289,73 +293,73 @@ See also [`S_min`](@ref).
 
 # Two site operators
 # ------------------
-@doc """
+"""
     S_x_S_x([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     SˣSˣ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The two-site operator ``S^x \\otimes S^x``.
 
 Compatible symmetries: `Trivial`, `Z2Irrep`.
-""" S_x_S_x
+"""
+@operator SˣSˣ S_x_S_x(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_x_S_x(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return S_x(elt, Trivial; spin) ⊗ S_x(elt, Trivial; spin)
 end
-const SˣSˣ = S_x_S_x
 
-@doc """
+"""
     S_y_S_y([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     SʸSʸ([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The two-site operator ``S^y \\otimes S^y``.
 
 Compatible symmetries: `Trivial`, `Z2Irrep`.
-""" S_y_S_y
+"""
+@operator SʸSʸ S_y_S_y(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_y_S_y(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     YY = S_y(complex(elt), Trivial; spin) ⊗ S_y(complex(elt), Trivial; spin)
     return elt <: Real ? real(YY) : YY
 end
-const SʸSʸ = S_y_S_y
 
-@doc """
+"""
     S_z_S_z([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     SᶻSᶻ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The two-site operator ``S^z \\otimes S^z``.
 
 Compatible symmetries: `Trivial`, `U1Irrep`, `Z2Irrep`.
-""" S_z_S_z
+"""
+@operator SᶻSᶻ S_z_S_z(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_z_S_z(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return S_z(elt, Trivial; spin) ⊗ S_z(elt, Trivial; spin)
 end
-const SᶻSᶻ = S_z_S_z
 
-@doc """
+"""
     S_plus_S_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     S⁺S⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The two-site operator ``S^+ \\otimes S^-``.
 
 Compatible symmetries: `Trivial`, `U1Irrep`.
-""" S_plus_S_min
+"""
+@operator S⁺S⁻ S_plus_S_min(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_plus_S_min(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return S_plus(elt, Trivial; spin) ⊗ S_min(elt, Trivial; spin)
 end
-const S⁺S⁻ = S_plus_S_min
 
-@doc """
+"""
     S_min_S_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     S⁻S⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The two-site operator ``S^- \\otimes S^+``.
 
 Compatible symmetries: `Trivial`, `U1Irrep`.
-""" S_min_S_plus
+"""
+@operator S⁻S⁺ S_min_S_plus(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_min_S_plus(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return S_min(elt, Trivial; spin) ⊗ S_plus(elt, Trivial; spin)
 end
-const S⁻S⁺ = S_min_S_plus
 
-@doc """
+"""
     S_exchange([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     SS([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
@@ -370,32 +374,11 @@ For `SU2Irrep` the operator is diagonal in the total-spin basis with eigenvalue
 ``\\tfrac{1}{2}[C_2(j_{\\text{tot}}) - 2C_2(s)]``, where ``C_2(j) = j(j+1)``.
 
 Compatible symmetries: `Trivial`, `U1Irrep`, `Z2Irrep`, `SU2Irrep`.
-""" S_exchange
+"""
+@operator SS S_exchange(::Type{<:Number}, ::Type{<:Sector}; spin)
 function S_exchange(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     return (S_plus_S_min(elt, Trivial; spin) + S_min_S_plus(elt, Trivial; spin)) / 2 +
         S_z_S_z(elt, Trivial; spin)
-end
-const SS = S_exchange
-
-# Symmetric operators and default arguments
-# -----------------------------------------
-# The symmetric operators are automatically generated from their `Trivial` counterparts
-# through `symmetrize` and `basis_transform`. Operators that are incompatible with a given
-# symmetry throw an `ArgumentError`.
-for opname in (
-        :S_x, :S_y, :S_z, :S_plus, :S_min,
-        :S_x_S_x, :S_y_S_y, :S_z_S_z, :S_plus_S_min, :S_min_S_plus, :S_exchange,
-    )
-    @eval begin
-        $opname(; kwargs...) = $opname(ComplexF64, Trivial; kwargs...)
-        $opname(elt::Type{<:Number}; kwargs...) = $opname(elt, Trivial; kwargs...)
-        $opname(symmetry::Type{<:Sector}; kwargs...) = $opname(ComplexF64, symmetry; kwargs...)
-        function $opname(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin = 1 // 2)
-            O = $opname(elt, Trivial; spin)
-            U = basis_transform(symmetry; spin)
-            return symmetrize(O, U, spin_space(symmetry; spin))
-        end
-    end
 end
 
 end

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -143,8 +143,10 @@ for (opname, alias) in zip(
     end
 
     # default arguments
+    @eval $opname(; slave_fermion::Bool = false) =
+        $opname(ComplexF64, Trivial, Trivial; slave_fermion)
     @eval $opname(
-        particle_symmetry::Type{<:Sector} = Trivial, spin_symmetry::Type{<:Sector} = Trivial;
+        particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
         slave_fermion::Bool = false
     ) = $opname(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
     @eval $opname(elt::Type{<:Number}; slave_fermion::Bool = false) =

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -25,7 +25,7 @@ export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
 export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
 export e⁺e⁻, e⁻e⁺, e_hop
 export singlet⁺, singlet⁻
-export S⁻S⁺, S⁺S⁻
+export S⁻S⁺, S⁺S⁻, SS
 
 export transform_slave_fermion
 
@@ -121,7 +121,7 @@ for (opname, alias) in zip(
             :u⁻u⁻, :u⁺u⁺, :d⁻d⁻, :d⁺d⁺,
             :e⁺e⁻, :e⁻e⁺, :e_hop,
             :singlet⁺, :singlet⁻,
-            :S⁻S⁺, :S⁺S⁻, nothing,
+            :S⁻S⁺, :S⁺S⁻, :SS,
         )
     )
     # copy over the docstrings

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -133,8 +133,8 @@ for (opname, alias) in zip(
             # compatibility with Julia 1.10 (hub_doc is a Markdown.MD object)
             string(hub_doc)
         end
-        tJ_doc = if occursin("[spin_symmetry::Type{<:Sector}])", tJ_doc)
-            replace(tJ_doc, "[spin_symmetry::Type{<:Sector}])" => "[spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)")
+        tJ_doc = if occursin("spin_symmetry::Type{<:Sector}])", tJ_doc)
+            replace(tJ_doc, "spin_symmetry::Type{<:Sector}])" => "spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)")
         else
             replace(tJ_doc, "spin_symmetry::Type{<:Sector})" => "spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)")
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -140,21 +140,21 @@ function fuse_local_operators(O₁::AbstractTensorMap, O₂::AbstractTensorMap)
         throw(ArgumentError("operators have incompatible space types"))
     (N = numout(O₁)) == numin(O₁) == numout(O₂) == numin(O₂) ||
         throw(ArgumentError("operators have incompatible number of indices"))
-
-    fuser = mapreduce(⊗, 1:N) do i
+    return _fuse_local_operators(Val(N), O₁, O₂)
+end
+function _fuse_local_operators(::Val{N}, O₁::AbstractTensorMap, O₂::AbstractTensorMap) where {N}
+    fuser = mapreduce(⊗, ntuple(identity, Val(N))) do i
         Vᵢ = space(O₁, i)
         Wᵢ = space(O₂, i)
         VWᵢ = fuse(Vᵢ, Wᵢ)
         return isomorphism(VWᵢ ← Vᵢ ⊗ Wᵢ)
     end
-
     O₁₂ = permute(
         O₁ ⊗ O₂, (
-            ntuple(i -> iseven(i) ? N + (i ÷ 2) : (i + 1) ÷ 2, 2N),
-            ntuple(i -> iseven(i) ? 3N + (i ÷ 2) : 2N + (i + 1) ÷ 2, 2N),
+            ntuple(i -> iseven(i) ? N + (i ÷ 2) : (i + 1) ÷ 2, Val(2N)),
+            ntuple(i -> iseven(i) ? 3N + (i ÷ 2) : 2N + (i + 1) ÷ 2, Val(2N)),
         )
     )
-
     return fuser * O₁₂ * fuser'
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -158,8 +158,98 @@ function _fuse_local_operators(::Val{N}, O₁::AbstractTensorMap, O₂::Abstract
     return fuser * O₁₂ * fuser'
 end
 
+# type annotation of a positional argument, from either `name::Type` or `::Type`
+function _operator_type_arg(a)
+    Meta.isexpr(a, :(::)) ||
+        throw(Meta.ParseError("`@operator`: positional arguments must be annotated as `name::Type` or `::Type`"))
+    return a.args[end]
+end
+
+# Build the block of forwarding methods (and optional alias) from the parsed reference
+# definition. Returned unescaped; the macro escapes it.
+function _operator_defs(alias, def, source)
+    Meta.isexpr(def, :function) ||
+        throw(Meta.ParseError("`@operator` expects `[alias] function op(...) ... end`"))
+    sig = def.args[1]
+    Meta.isexpr(sig, :call) ||
+        throw(Meta.ParseError("`@operator`: the wrapped definition must be a function call signature"))
+    fname = sig.args[1]
+    (fname isa Symbol) ||
+        throw(ArgumentError("`@operator`: the operator name must be a symbol"))
+
+    posargs = filter(a -> !Meta.isexpr(a, :parameters), sig.args[2:end])
+    length(posargs) >= 1 ||
+        throw(ArgumentError("`@operator` expects at least an element type argument"))
+
+    eltconstraint = _operator_type_arg(posargs[1])
+    N = length(posargs) - 1  # number of symmetry arguments; may be zero
+
+    loc = LineNumberNode(source.line, source.file)
+    # every generated method takes and forwards `kwargs...` verbatim; only the wrapped
+    # reference method validates keyword names, defaults, and types. signatures and calls
+    # share the same `f(args...; kwargs...)` shape, so a single builder covers both.
+    kwargs = gensym(:kwargs)
+    call_expr(f, cargs...) = Expr(:call, f, Expr(:parameters, Expr(:..., kwargs)), cargs...)
+    method_def(msig, body) = Expr(:function, msig, Expr(:block, loc, body))
+
+    # `op(; kwargs...) = op(ComplexF64, Trivial, …; kwargs...)` — always emitted; fills the
+    # element type default (and any symmetry defaults). This is the doc'd method.
+    method_none = method_def(
+        call_expr(fname),
+        call_expr(fname, :ComplexF64, ntuple(Returns(:Trivial), N)...)
+    )
+
+    # With no symmetry arguments the wrapped reference method is itself the terminal, so
+    # `method_none` (plus the reference's own `op(elt; …)`) is all that is needed. With one
+    # or more symmetries, symmetries are all-or-nothing and we additionally emit the
+    # symmetry-first, elt-only, and symmetric-terminal methods.
+    extra_methods = if N == 0
+        ()
+    else
+        # `op(s₁::Type{<:Sector}, …, sₙ::Type{<:Sector}; kwargs...) =
+        #      op(ComplexF64, s₁, …, sₙ; kwargs...)`
+        snames = [gensym(:S) for _ in 1:N]
+        symsig = call_expr(
+            fname, (Expr(:(::), snames[i], :(Type{<:Sector})) for i in 1:N)...
+        )
+        symcall = call_expr(fname, :ComplexF64, snames...)
+        method_allsyms = method_def(symsig, symcall)
+
+        # `op(elt::<eltconstraint>; kwargs...) = op(elt, Trivial, …; kwargs...)`
+        eltname = gensym(:elt)
+        eltsig = call_expr(fname, Expr(:(::), eltname, eltconstraint))
+        eltcall = call_expr(fname, eltname, ntuple(Returns(:Trivial), N)...)
+        method_elt = method_def(eltsig, eltcall)
+
+        # symmetric terminal:
+        # `op(elt::<c>, s₁::Type{<:Sector}, …; kwargs...) =
+        #      _symmetrize_operator(op(elt, Trivial, …; kwargs...), s₁, …; kwargs...)`
+        tname = gensym(:elt)
+        tsyms = [gensym(:S) for _ in 1:N]
+        tsig = call_expr(
+            fname, Expr(:(::), tname, eltconstraint),
+            (Expr(:(::), tsyms[i], :(Type{<:Sector})) for i in 1:N)...
+        )
+        refcall = call_expr(fname, tname, ntuple(Returns(:Trivial), N)...)
+        hookcall = call_expr(:_symmetrize_operator, refcall, tsyms...)
+        method_terminal = method_def(tsig, hookcall)
+
+        (method_allsyms, method_elt, method_terminal)
+    end
+
+    aliasdef = alias === nothing ? nothing : Expr(:const, Expr(:(=), alias, fname))
+
+    return quote
+        $def
+        Core.@__doc__ $method_none
+        $(extra_methods...)
+        $loc
+        $aliasdef
+    end
+end
+
 """
-    @operator [alias] function op(elt::Type{<:Number}, ::Type{Trivial}, …; kwargs...)
+    @operator [alias] function op(elt::Type{<:Number}[, ::Type{Trivial}, …]; kwargs...)
         ...
     end
 
@@ -168,9 +258,9 @@ reference implementation. The wrapped method is the single source of truth for t
 element type constraint, number of symmetry slots, keyword names, keyword defaults, and
 keyword type annotations.
 
-The wrapped signature must have an element type as its first positional argument, followed by
-one or more concrete `::Type{Trivial}` symmetry arguments. `@operator` emits the boilerplate so
-that all of the following resolve:
+The wrapped signature must have an element type as its first positional argument, optionally
+followed by one or more symmetry arguments (conventionally annotated `::Type{Trivial}`).
+`@operator` emits the boilerplate so that all of the following resolve:
 
 - `op()`
 - `op(eltype)`
@@ -181,13 +271,17 @@ The element type defaults to `ComplexF64`, and omitted symmetries default to `Tr
 Symmetries are all-or-nothing: either all of them are given, or none are. This avoids silently
 defaulting the unspecified symmetries of a multi-symmetry operator.
 
-The last generated method, the *symmetric terminal*, delegates to the module-local hook
+If the reference method takes no symmetry arguments, it is itself the terminal: only the
+`op()` element-type default is generated (the symmetry-first, elt-only, and symmetric-terminal
+methods, including the `_symmetrize_operator` hook, are omitted).
+
+Otherwise, the last generated method, the *symmetric terminal*, delegates to the module-local
+hook
 `_symmetrize_operator(op(elt, Trivial, …; kwargs...), symmetry₁, …; kwargs...)`, which each
 operator module defines once (typically wrapping [`symmetrize`](@ref) with the module's
-`basis_transform` and local space). Keyword arguments are copied from the wrapped reference
-method and forwarded by name to both the reference call and the hook. Vararg keywords
-(`kwargs...`) are rejected because the public keyword interface is inferred from the concrete
-method signature.
+`basis_transform` and local space). Every generated method simply accepts `kwargs...` and
+forwards them verbatim to both the reference call and the hook; the wrapped reference method
+is the only place that validates keyword names, defaults, and types.
 
 If an `alias` symbol is supplied, a `const alias = op` binding is emitted as well (e.g. the
 Unicode name `Sᶻ` for `S_z`).
@@ -208,114 +302,13 @@ end
 """
 macro operator(args...)
     (1 <= length(args) <= 2) ||
-        error("`@operator` expects `[alias] function op(...) ... end`")
+        throw(Meta.ParseError("`@operator` expects `[alias] function op(...) ... end`"))
     if length(args) == 2
         alias, def = args[1], args[2]
-        (alias isa Symbol) || error("`@operator`: the alias must be a symbol")
+        (alias isa Symbol) ||
+            throw(ArgumentError("`@operator`: the alias must be a symbol"))
     else
         alias, def = nothing, args[1]
     end
-
-    (def isa Expr && def.head === :function) ||
-        error("`@operator` expects `[alias] function op(...) ... end`")
-    sig = def.args[1]
-    (sig isa Expr && sig.head === :call) ||
-        error("`@operator`: the wrapped definition must be a function call signature")
-    fname = sig.args[1]
-    (fname isa Symbol) || error("`@operator`: the operator name must be a symbol")
-    params = findfirst(a -> a isa Expr && a.head === :parameters, sig.args)
-    kwtemplate = params === nothing ? Any[] : sig.args[params].args
-    posargs = filter(a -> !(a isa Expr && a.head === :parameters), sig.args[2:end])
-    length(posargs) >= 2 ||
-        error("`@operator` expects an element type plus at least one symmetry argument")
-
-    function parse_type_arg(a)
-        (a isa Expr && a.head === :(::)) ||
-            error("`@operator`: positional arguments must be annotated as `name::Type` or `::Type`")
-        return a.args[end]
-    end
-
-    function is_trivial_type(t)
-        return t isa Expr && t.head === :curly && t.args == Any[:Type, :Trivial]
-    end
-
-    function kwname(kwarg)
-        kwarg isa Expr && kwarg.head === :(...) &&
-            error("`@operator`: keyword varargs `kwargs...` are not supported")
-        inner = kwarg isa Expr && kwarg.head === :kw ? kwarg.args[1] : kwarg
-        if inner isa Expr && inner.head === :(::)
-            (inner.args[1] isa Symbol) ||
-                error("`@operator`: keyword arguments must have a name")
-            return inner.args[1]
-        end
-        inner isa Symbol || error("`@operator`: keyword arguments must have a name")
-        return inner
-    end
-
-    eltconstraint = parse_type_arg(posargs[1])
-    for symarg in posargs[2:end]
-        is_trivial_type(parse_type_arg(symarg)) ||
-            error("`@operator`: symmetry arguments in the reference method must be `::Type{Trivial}`")
-    end
-    kwnames = map(kwname, kwtemplate)
-    N = length(posargs) - 1
-
-    loc = LineNumberNode(__source__.line, __source__.file)
-    method_def(sig, body) = Expr(:function, sig, Expr(:block, loc, body))
-    kwparams() = isempty(kwtemplate) ? () : (Expr(:parameters, deepcopy.(kwtemplate)...),)
-    kwforward() = isempty(kwnames) ? () :
-        (Expr(:parameters, (Expr(:kw, name, name) for name in kwnames)...),)
-    call_expr(f, args...) = Expr(:call, f, kwforward()..., args...)
-    sig_expr(f, args...) = Expr(:call, f, kwparams()..., args...)
-
-    # symmetries are all-or-nothing:
-    # emit a no-symmetry method and an all-symmetries method
-
-    # `op(; kwargs...) = op(ComplexF64, Trivial, …; kwargs...)`
-    method_none = method_def(
-        sig_expr(fname),
-        call_expr(fname, :ComplexF64, ntuple(Returns(:Trivial), N)...)
-    )
-
-    # `op(s₁::Type{<:Sector}, …, sₙ::Type{<:Sector}; kwargs...) =
-    #      op(ComplexF64, s₁, …, sₙ; kwargs...)`
-    snames = [gensym(:S) for _ in 1:N]
-    symsig = sig_expr(
-        fname, (Expr(:(::), snames[i], :(Type{<:Sector})) for i in 1:N)...
-    )
-    symcall = call_expr(fname, :ComplexF64, snames...)
-    method_allsyms = method_def(symsig, symcall)
-
-    # `op(elt::<eltconstraint>; kwargs...) = op(elt, Trivial, …; kwargs...)`
-    eltname = gensym(:elt)
-    eltsig = sig_expr(fname, Expr(:(::), eltname, eltconstraint))
-    eltcall = call_expr(fname, eltname, ntuple(Returns(:Trivial), N)...)
-    method_elt = method_def(eltsig, eltcall)
-
-    # symmetric terminal:
-    # `op(elt::<c>, s₁::Type{<:Sector}, …; kwargs...) =
-    #      _symmetrize_operator(op(elt, Trivial, …; kwargs...), s₁, …; kwargs...)`
-    tname = gensym(:elt)
-    tsyms = [gensym(:S) for _ in 1:N]
-    tsig = sig_expr(
-        fname, Expr(:(::), tname, eltconstraint),
-        (Expr(:(::), tsyms[i], :(Type{<:Sector})) for i in 1:N)...
-    )
-    refcall = call_expr(fname, tname, ntuple(Returns(:Trivial), N)...)
-    hookcall = call_expr(:_symmetrize_operator, refcall, tsyms...)
-    method_terminal = method_def(tsig, hookcall)
-
-    aliasdef = alias === nothing ? nothing : Expr(:const, Expr(:(=), alias, fname))
-
-    return esc(
-        quote
-            $def
-            Core.@__doc__ $method_none
-            $method_allsyms
-            $method_elt
-            $method_terminal
-            $loc
-            $aliasdef
-        end
-    )
+    return esc(_operator_defs(alias, def, __source__))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -159,40 +159,41 @@ function fuse_local_operators(O₁::AbstractTensorMap, O₂::AbstractTensorMap)
 end
 
 """
-    @operator [alias] op(::Type{<:Number}[=default], ::Type{<:Sector}[=default], …; kwargs...)
+    @operator [alias] function op(elt::Type{<:Number}, ::Type{Trivial}, …; kwargs...)
+        ...
+    end
 
-Generate the public default-argument interface for an operator whose non-symmetric reference
-implementation `op(elt, Trivial, …; kwargs...)` (with a concrete `::Type{Trivial}` for each
-symmetry slot) is written separately.
+Generate the public default-argument interface for an operator from its non-symmetric
+reference implementation. The wrapped method is the single source of truth for the operator's
+element type constraint, number of symmetry slots, keyword names, keyword defaults, and
+keyword type annotations.
 
-The signature is a *template* describing the public interface: an element type as the first
-positional argument, followed by one or more symmetry arguments, and optionally some keyword
-arguments. Each argument's type annotation constrains the corresponding generated method, and
-each `= default` supplies the value filled in when the argument is omitted (the element type
-defaults to `ComplexF64` and symmetries to `Trivial`). The element type is independently
-optional, but the symmetries are all-or-nothing: either all of them are given, or none are
-(in which case they take their defaults). This avoids silently defaulting the unspecified
-symmetries of a multi-symmetry operator. `@operator` emits the boilerplate so that all of the
-following resolve:
+The wrapped signature must have an element type as its first positional argument, followed by
+one or more concrete `::Type{Trivial}` symmetry arguments. `@operator` emits the boilerplate so
+that all of the following resolve:
 
 - `op()`
 - `op(eltype)`
 - `op(symmetry₁, …, symmetryₙ)` (all symmetries)
 - `op(eltype, symmetry₁, …, symmetryₙ)`
 
-The last of these, the *symmetric terminal*, delegates to the module-local hook
+The element type defaults to `ComplexF64`, and omitted symmetries default to `Trivial`.
+Symmetries are all-or-nothing: either all of them are given, or none are. This avoids silently
+defaulting the unspecified symmetries of a multi-symmetry operator.
+
+The last generated method, the *symmetric terminal*, delegates to the module-local hook
 `_symmetrize_operator(op(elt, Trivial, …; kwargs...), symmetry₁, …; kwargs...)`, which each
 operator module defines once (typically wrapping [`symmetrize`](@ref) with the module's
-`basis_transform` and local space). Keyword arguments (`spin`, `cutoff`, …) are forwarded
-generically to both the reference call and the hook; the `kwargs` in the template are only for
-documentation.
+`basis_transform` and local space). Keyword arguments are copied from the wrapped reference
+method and forwarded by name to both the reference call and the hook. Vararg keywords
+(`kwargs...`) are rejected because the public keyword interface is inferred from the concrete
+method signature.
 
 If an `alias` symbol is supplied, a `const alias = op` binding is emitted as well (e.g. the
 Unicode name `Sᶻ` for `S_z`).
 
 The first generated method is wrapped in `Core.@__doc__`, so a docstring written directly
-above the `@operator` line is attached to the operator function. Write the reference
-method(s) as ordinary definitions, either above or below the `@operator` line:
+above the `@operator` line is attached to the operator function:
 
 ```julia
 \"\"\"
@@ -200,75 +201,97 @@ method(s) as ordinary definitions, either above or below the `@operator` line:
 
 The spin-z operator.
 \"\"\"
-@operator Sᶻ S_z(::Type{<:Number}, ::Type{<:Sector}; spin)
-function S_z(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+@operator Sᶻ function S_z(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
     ...
 end
 ```
 """
 macro operator(args...)
     (1 <= length(args) <= 2) ||
-        error("`@operator` expects `[alias] op(signature)`")
+        error("`@operator` expects `[alias] function op(...) ... end`")
     if length(args) == 2
-        alias, sig = args[1], args[2]
+        alias, def = args[1], args[2]
         (alias isa Symbol) || error("`@operator`: the alias must be a symbol")
     else
-        alias, sig = nothing, args[1]
+        alias, def = nothing, args[1]
     end
 
+    (def isa Expr && def.head === :function) ||
+        error("`@operator` expects `[alias] function op(...) ... end`")
+    sig = def.args[1]
     (sig isa Expr && sig.head === :call) ||
-        error("`@operator` expects a signature template `op(::Type{...}, …)`")
+        error("`@operator`: the wrapped definition must be a function call signature")
     fname = sig.args[1]
     (fname isa Symbol) || error("`@operator`: the operator name must be a symbol")
+    params = findfirst(a -> a isa Expr && a.head === :parameters, sig.args)
+    kwtemplate = params === nothing ? Any[] : sig.args[params].args
     posargs = filter(a -> !(a isa Expr && a.head === :parameters), sig.args[2:end])
     length(posargs) >= 2 ||
         error("`@operator` expects an element type plus at least one symmetry argument")
 
-    # parse an argument into (type constraint, default-or-nothing)
-    function parse_arg(a)
-        inner, default = (a isa Expr && a.head === :kw) ? (a.args[1], a.args[2]) : (a, nothing)
-        (inner isa Expr && inner.head === :(::)) ||
-            error("`@operator`: each argument must be `::Type{...}` (optionally `= default`)")
-        return inner.args[end], default
+    function parse_type_arg(a)
+        (a isa Expr && a.head === :(::)) ||
+            error("`@operator`: positional arguments must be annotated as `name::Type` or `::Type`")
+        return a.args[end]
     end
 
-    # set default values if not given: `elt = ComplexF64` and `symmetry = Trivial`
-    eltconstraint, eltdefault = parse_arg(posargs[1])
-    eltdefault === nothing && (eltdefault = :ComplexF64)
-    syms = map(parse_arg, posargs[2:end])
-    symconstraints = first.(syms)
-    symdefaults = map(s -> s[2] === nothing ? :Trivial : s[2], syms)
-    N = length(syms)
+    function is_trivial_type(t)
+        return t isa Expr && t.head === :curly && t.args == Any[:Type, :Trivial]
+    end
 
-    kw = gensym(:kwargs)
-    kwparam = Expr(:parameters, Expr(:(...), kw))
+    function kwname(kwarg)
+        kwarg isa Expr && kwarg.head === :(...) &&
+            error("`@operator`: keyword varargs `kwargs...` are not supported")
+        inner = kwarg isa Expr && kwarg.head === :kw ? kwarg.args[1] : kwarg
+        if inner isa Expr && inner.head === :(::)
+            (inner.args[1] isa Symbol) ||
+                error("`@operator`: keyword arguments must have a name")
+            return inner.args[1]
+        end
+        inner isa Symbol || error("`@operator`: keyword arguments must have a name")
+        return inner
+    end
+
+    eltconstraint = parse_type_arg(posargs[1])
+    for symarg in posargs[2:end]
+        is_trivial_type(parse_type_arg(symarg)) ||
+            error("`@operator`: symmetry arguments in the reference method must be `::Type{Trivial}`")
+    end
+    kwnames = map(kwname, kwtemplate)
+    N = length(posargs) - 1
+
     loc = LineNumberNode(__source__.line, __source__.file)
     method_def(sig, body) = Expr(:function, sig, Expr(:block, loc, body))
+    kwparams() = isempty(kwtemplate) ? () : (Expr(:parameters, deepcopy.(kwtemplate)...),)
+    kwforward() = isempty(kwnames) ? () :
+        (Expr(:parameters, (Expr(:kw, name, name) for name in kwnames)...),)
+    call_expr(f, args...) = Expr(:call, f, kwforward()..., args...)
+    sig_expr(f, args...) = Expr(:call, f, kwparams()..., args...)
 
     # symmetries are all-or-nothing: emit a no-symmetry method and an all-symmetries
     # method rather than per-argument defaults, which would also accept partial prefixes
     # (e.g. `op(sym₁)` for a two-symmetry operator) and thereby silently default the
     # remaining symmetries to `Trivial`.
 
-    # `op(; kwargs...) = op(<eltdefault>, <d₁>, …; kwargs...)`
+    # `op(; kwargs...) = op(ComplexF64, Trivial, …; kwargs...)`
     method_none = method_def(
-        Expr(:call, fname, kwparam),
-        Expr(:call, fname, kwparam, eltdefault, symdefaults...)
+        sig_expr(fname),
+        call_expr(fname, :ComplexF64, ntuple(Returns(:Trivial), N)...)
     )
 
-    # `op(s₁::<c₁>, …, sₙ::<cₙ>; kwargs...) = op(<eltdefault>, s₁, …; kwargs...)`
+    # `op(s₁::Type{<:Sector}, …, sₙ::Type{<:Sector}; kwargs...) =
+    #      op(ComplexF64, s₁, …; kwargs...)`
     snames = [gensym(:S) for _ in 1:N]
-    symsig = Expr(
-        :call, fname, kwparam,
-        (Expr(:(::), snames[i], symconstraints[i]) for i in 1:N)...
+    symsig = sig_expr(
+        fname, (Expr(:(::), snames[i], :(Type{<:Sector})) for i in 1:N)...
     )
-    symcall = Expr(:call, fname, kwparam, eltdefault, snames...)
+    symcall = call_expr(fname, :ComplexF64, snames...)
     method_allsyms = method_def(symsig, symcall)
 
-    # `op(elt::<eltconstraint>; kwargs...) = op(elt, <d₁>, …; kwargs...)`
+    # `op(elt::<eltconstraint>; kwargs...) = op(elt, Trivial, …; kwargs...)`
     eltname = gensym(:elt)
-    eltsig = Expr(:call, fname, kwparam, Expr(:(::), eltname, eltconstraint))
-    eltcall = Expr(:call, fname, kwparam, eltname, symdefaults...)
+    eltsig = sig_expr(fname, Expr(:(::), eltname, eltconstraint))
+    eltcall = call_expr(fname, eltname, ntuple(Returns(:Trivial), N)...)
     method_elt = method_def(eltsig, eltcall)
 
     # symmetric terminal:
@@ -276,18 +299,19 @@ macro operator(args...)
     #      _symmetrize_operator(op(elt, Trivial, …; kwargs...), s₁, …; kwargs...)`
     tname = gensym(:elt)
     tsyms = [gensym(:S) for _ in 1:N]
-    tsig = Expr(
-        :call, fname, kwparam, Expr(:(::), tname, eltconstraint),
-        (Expr(:(::), tsyms[i], symconstraints[i]) for i in 1:N)...
+    tsig = sig_expr(
+        fname, Expr(:(::), tname, eltconstraint),
+        (Expr(:(::), tsyms[i], :(Type{<:Sector})) for i in 1:N)...
     )
-    refcall = Expr(:call, fname, kwparam, tname, ntuple(Returns(:Trivial), N)...)
-    hookcall = Expr(:call, :_symmetrize_operator, kwparam, refcall, tsyms...)
+    refcall = call_expr(fname, tname, ntuple(Returns(:Trivial), N)...)
+    hookcall = call_expr(:_symmetrize_operator, refcall, tsyms...)
     method_terminal = method_def(tsig, hookcall)
 
     aliasdef = alias === nothing ? nothing : Expr(:const, Expr(:(=), alias, fname))
 
     return esc(
         quote
+            $def
             Core.@__doc__ $method_none
             $method_allsyms
             $method_elt

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -242,6 +242,8 @@ macro operator(args...)
 
     kw = gensym(:kwargs)
     kwparam = Expr(:parameters, Expr(:(...), kw))
+    loc = LineNumberNode(__source__.line, __source__.file)
+    method_def(sig, body) = Expr(:function, sig, Expr(:block, loc, body))
 
     # symmetries are all-or-nothing: emit a no-symmetry method and an all-symmetries
     # method rather than per-argument defaults, which would also accept partial prefixes
@@ -249,8 +251,8 @@ macro operator(args...)
     # remaining symmetries to `Trivial`.
 
     # `op(; kwargs...) = op(<eltdefault>, <d₁>, …; kwargs...)`
-    method_none = Expr(
-        :(=), Expr(:call, fname, kwparam),
+    method_none = method_def(
+        Expr(:call, fname, kwparam),
         Expr(:call, fname, kwparam, eltdefault, symdefaults...)
     )
 
@@ -261,13 +263,13 @@ macro operator(args...)
         (Expr(:(::), snames[i], symconstraints[i]) for i in 1:N)...
     )
     symcall = Expr(:call, fname, kwparam, eltdefault, snames...)
-    method_allsyms = Expr(:(=), symsig, symcall)
+    method_allsyms = method_def(symsig, symcall)
 
     # `op(elt::<eltconstraint>; kwargs...) = op(elt, <d₁>, …; kwargs...)`
     eltname = gensym(:elt)
     eltsig = Expr(:call, fname, kwparam, Expr(:(::), eltname, eltconstraint))
     eltcall = Expr(:call, fname, kwparam, eltname, symdefaults...)
-    method_elt = Expr(:(=), eltsig, eltcall)
+    method_elt = method_def(eltsig, eltcall)
 
     # symmetric terminal:
     # `op(elt::<c>, s₁::Type{<:Sector}, …; kwargs...) =
@@ -280,7 +282,7 @@ macro operator(args...)
     )
     refcall = Expr(:call, fname, kwparam, tname, ntuple(Returns(:Trivial), N)...)
     hookcall = Expr(:call, :_symmetrize_operator, kwparam, refcall, tsyms...)
-    method_terminal = Expr(:(=), tsig, hookcall)
+    method_terminal = method_def(tsig, hookcall)
 
     aliasdef = alias === nothing ? nothing : Expr(:const, Expr(:(=), alias, fname))
 
@@ -290,6 +292,7 @@ macro operator(args...)
             $method_allsyms
             $method_elt
             $method_terminal
+            $loc
             $aliasdef
         end
     )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -169,12 +169,15 @@ The signature is a *template* describing the public interface: an element type a
 positional argument, followed by one or more symmetry arguments, and optionally some keyword
 arguments. Each argument's type annotation constrains the corresponding generated method, and
 each `= default` supplies the value filled in when the argument is omitted (the element type
-defaults to `ComplexF64` and symmetries to `Trivial`). `@operator` emits the boilerplate so
-that all of the following resolve:
+defaults to `ComplexF64` and symmetries to `Trivial`). The element type is independently
+optional, but the symmetries are all-or-nothing: either all of them are given, or none are
+(in which case they take their defaults). This avoids silently defaulting the unspecified
+symmetries of a multi-symmetry operator. `@operator` emits the boilerplate so that all of the
+following resolve:
 
 - `op()`
 - `op(eltype)`
-- `op(symmetry₁, …, symmetryₙ)` (any prefix; remaining symmetries take their defaults)
+- `op(symmetry₁, …, symmetryₙ)` (all symmetries)
 - `op(eltype, symmetry₁, …, symmetryₙ)`
 
 The last of these, the *symmetric terminal*, delegates to the module-local hook
@@ -240,14 +243,25 @@ macro operator(args...)
     kw = gensym(:kwargs)
     kwparam = Expr(:parameters, Expr(:(...), kw))
 
-    # `op(s₁::<c₁> = <d₁>, …; kwargs...) = op(<eltdefault>, s₁, …; kwargs...)`
+    # symmetries are all-or-nothing: emit a no-symmetry method and an all-symmetries
+    # method rather than per-argument defaults, which would also accept partial prefixes
+    # (e.g. `op(sym₁)` for a two-symmetry operator) and thereby silently default the
+    # remaining symmetries to `Trivial`.
+
+    # `op(; kwargs...) = op(<eltdefault>, <d₁>, …; kwargs...)`
+    method_none = Expr(
+        :(=), Expr(:call, fname, kwparam),
+        Expr(:call, fname, kwparam, eltdefault, symdefaults...)
+    )
+
+    # `op(s₁::<c₁>, …, sₙ::<cₙ>; kwargs...) = op(<eltdefault>, s₁, …; kwargs...)`
     snames = [gensym(:S) for _ in 1:N]
     symsig = Expr(
         :call, fname, kwparam,
-        (Expr(:kw, Expr(:(::), snames[i], symconstraints[i]), symdefaults[i]) for i in 1:N)...
+        (Expr(:(::), snames[i], symconstraints[i]) for i in 1:N)...
     )
     symcall = Expr(:call, fname, kwparam, eltdefault, snames...)
-    method_sym = Expr(:(=), symsig, symcall)
+    method_allsyms = Expr(:(=), symsig, symcall)
 
     # `op(elt::<eltconstraint>; kwargs...) = op(elt, <d₁>, …; kwargs...)`
     eltname = gensym(:elt)
@@ -272,7 +286,8 @@ macro operator(args...)
 
     return esc(
         quote
-            Core.@__doc__ $method_sym
+            Core.@__doc__ $method_none
+            $method_allsyms
             $method_elt
             $method_terminal
             $aliasdef

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -268,10 +268,8 @@ macro operator(args...)
     call_expr(f, args...) = Expr(:call, f, kwforward()..., args...)
     sig_expr(f, args...) = Expr(:call, f, kwparams()..., args...)
 
-    # symmetries are all-or-nothing: emit a no-symmetry method and an all-symmetries
-    # method rather than per-argument defaults, which would also accept partial prefixes
-    # (e.g. `op(sym₁)` for a two-symmetry operator) and thereby silently default the
-    # remaining symmetries to `Trivial`.
+    # symmetries are all-or-nothing:
+    # emit a no-symmetry method and an all-symmetries method
 
     # `op(; kwargs...) = op(ComplexF64, Trivial, …; kwargs...)`
     method_none = method_def(
@@ -280,7 +278,7 @@ macro operator(args...)
     )
 
     # `op(s₁::Type{<:Sector}, …, sₙ::Type{<:Sector}; kwargs...) =
-    #      op(ComplexF64, s₁, …; kwargs...)`
+    #      op(ComplexF64, s₁, …, sₙ; kwargs...)`
     snames = [gensym(:S) for _ in 1:N]
     symsig = sig_expr(
         fname, (Expr(:(::), snames[i], :(Type{<:Sector})) for i in 1:N)...

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -135,15 +135,10 @@ end
 Given two ``n``-body operators, acting on ``ℋ₁ = V₁ ⊗ ⋯ ⊗ Vₙ`` and ``ℋ₂ = W₁ ⊗ ⋯ ⊗ Wₙ``,
 return the operator acting on the fused local spaces, i.e. on ``ℋ = fuse(V₁ ⊗ W₁) ⊗ ⋯ ⊗ fuse(Vₙ ⊗ Wₙ)``.
 """
-function fuse_local_operators(O₁::AbstractTensorMap, O₂::AbstractTensorMap)
-    spacetype(O₁) == spacetype(O₂) ||
-        throw(ArgumentError("operators have incompatible space types"))
-    (N = numout(O₁)) == numin(O₁) == numout(O₂) == numin(O₂) ||
-        throw(ArgumentError("operators have incompatible number of indices"))
-    return _fuse_local_operators(Val(N), O₁, O₂)
-end
-function _fuse_local_operators(::Val{N}, O₁::AbstractTensorMap, O₂::AbstractTensorMap) where {N}
-    fuser = mapreduce(⊗, ntuple(identity, Val(N))) do i
+function fuse_local_operators(O₁::AbstractTensorMap{<:Any, S₁, N₁, N₂}, O₂::AbstractTensorMap{<:Any, S₂, N₃, N₄}) where {S₁, S₂, N₁, N₂, N₃, N₄}
+    S₁ == S₂ || throw(ArgumentError("operators have incompatible space types"))
+    (N₁ == N₂ == N₃ == N₄) || throw(ArgumentError("operators have incompatible number of indices"))
+    fuser = mapreduce(⊗, ntuple(identity, Val(N₁))) do i
         Vᵢ = space(O₁, i)
         Wᵢ = space(O₂, i)
         VWᵢ = fuse(Vᵢ, Wᵢ)
@@ -151,8 +146,8 @@ function _fuse_local_operators(::Val{N}, O₁::AbstractTensorMap, O₂::Abstract
     end
     O₁₂ = permute(
         O₁ ⊗ O₂, (
-            ntuple(i -> iseven(i) ? N + (i ÷ 2) : (i + 1) ÷ 2, Val(2N)),
-            ntuple(i -> iseven(i) ? 3N + (i ÷ 2) : 2N + (i + 1) ÷ 2, Val(2N)),
+            ntuple(i -> iseven(i) ? N₁ + (i ÷ 2) : (i + 1) ÷ 2, Val(2N₁)),
+            ntuple(i -> iseven(i) ? 3N₁ + (i ÷ 2) : 2N₁ + (i + 1) ÷ 2, Val(2N₁)),
         )
     )
     return fuser * O₁₂ * fuser'

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -157,3 +157,125 @@ function fuse_local_operators(O₁::AbstractTensorMap, O₂::AbstractTensorMap)
 
     return fuser * O₁₂ * fuser'
 end
+
+"""
+    @operator [alias] op(::Type{<:Number}[=default], ::Type{<:Sector}[=default], …; kwargs...)
+
+Generate the public default-argument interface for an operator whose non-symmetric reference
+implementation `op(elt, Trivial, …; kwargs...)` (with a concrete `::Type{Trivial}` for each
+symmetry slot) is written separately.
+
+The signature is a *template* describing the public interface: an element type as the first
+positional argument, followed by one or more symmetry arguments, and optionally some keyword
+arguments. Each argument's type annotation constrains the corresponding generated method, and
+each `= default` supplies the value filled in when the argument is omitted (the element type
+defaults to `ComplexF64` and symmetries to `Trivial`). `@operator` emits the boilerplate so
+that all of the following resolve:
+
+- `op()`
+- `op(eltype)`
+- `op(symmetry₁, …, symmetryₙ)` (any prefix; remaining symmetries take their defaults)
+- `op(eltype, symmetry₁, …, symmetryₙ)`
+
+The last of these, the *symmetric terminal*, delegates to the module-local hook
+`_symmetrize_operator(op(elt, Trivial, …; kwargs...), symmetry₁, …; kwargs...)`, which each
+operator module defines once (typically wrapping [`symmetrize`](@ref) with the module's
+`basis_transform` and local space). Keyword arguments (`spin`, `cutoff`, …) are forwarded
+generically to both the reference call and the hook; the `kwargs` in the template are only for
+documentation.
+
+If an `alias` symbol is supplied, a `const alias = op` binding is emitted as well (e.g. the
+Unicode name `Sᶻ` for `S_z`).
+
+The first generated method is wrapped in `Core.@__doc__`, so a docstring written directly
+above the `@operator` line is attached to the operator function. Write the reference
+method(s) as ordinary definitions, either above or below the `@operator` line:
+
+```julia
+\"\"\"
+    S_z([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+
+The spin-z operator.
+\"\"\"
+@operator Sᶻ S_z(::Type{<:Number}, ::Type{<:Sector}; spin)
+function S_z(elt::Type{<:Number}, ::Type{Trivial}; spin = 1 // 2)
+    ...
+end
+```
+"""
+macro operator(args...)
+    (1 <= length(args) <= 2) ||
+        error("`@operator` expects `[alias] op(signature)`")
+    if length(args) == 2
+        alias, sig = args[1], args[2]
+        (alias isa Symbol) || error("`@operator`: the alias must be a symbol")
+    else
+        alias, sig = nothing, args[1]
+    end
+
+    (sig isa Expr && sig.head === :call) ||
+        error("`@operator` expects a signature template `op(::Type{...}, …)`")
+    fname = sig.args[1]
+    (fname isa Symbol) || error("`@operator`: the operator name must be a symbol")
+    posargs = filter(a -> !(a isa Expr && a.head === :parameters), sig.args[2:end])
+    length(posargs) >= 2 ||
+        error("`@operator` expects an element type plus at least one symmetry argument")
+
+    # parse an argument into (type constraint, default-or-nothing)
+    function parse_arg(a)
+        inner, default = (a isa Expr && a.head === :kw) ? (a.args[1], a.args[2]) : (a, nothing)
+        (inner isa Expr && inner.head === :(::)) ||
+            error("`@operator`: each argument must be `::Type{...}` (optionally `= default`)")
+        return inner.args[end], default
+    end
+
+    # set default values if not given: `elt = ComplexF64` and `symmetry = Trivial`
+    eltconstraint, eltdefault = parse_arg(posargs[1])
+    eltdefault === nothing && (eltdefault = :ComplexF64)
+    syms = map(parse_arg, posargs[2:end])
+    symconstraints = first.(syms)
+    symdefaults = map(s -> s[2] === nothing ? :Trivial : s[2], syms)
+    N = length(syms)
+
+    kw = gensym(:kwargs)
+    kwparam = Expr(:parameters, Expr(:(...), kw))
+
+    # `op(s₁::<c₁> = <d₁>, …; kwargs...) = op(<eltdefault>, s₁, …; kwargs...)`
+    snames = [gensym(:S) for _ in 1:N]
+    symsig = Expr(
+        :call, fname, kwparam,
+        (Expr(:kw, Expr(:(::), snames[i], symconstraints[i]), symdefaults[i]) for i in 1:N)...
+    )
+    symcall = Expr(:call, fname, kwparam, eltdefault, snames...)
+    method_sym = Expr(:(=), symsig, symcall)
+
+    # `op(elt::<eltconstraint>; kwargs...) = op(elt, <d₁>, …; kwargs...)`
+    eltname = gensym(:elt)
+    eltsig = Expr(:call, fname, kwparam, Expr(:(::), eltname, eltconstraint))
+    eltcall = Expr(:call, fname, kwparam, eltname, symdefaults...)
+    method_elt = Expr(:(=), eltsig, eltcall)
+
+    # symmetric terminal:
+    # `op(elt::<c>, s₁::Type{<:Sector}, …; kwargs...) =
+    #      _symmetrize_operator(op(elt, Trivial, …; kwargs...), s₁, …; kwargs...)`
+    tname = gensym(:elt)
+    tsyms = [gensym(:S) for _ in 1:N]
+    tsig = Expr(
+        :call, fname, kwparam, Expr(:(::), tname, eltconstraint),
+        (Expr(:(::), tsyms[i], symconstraints[i]) for i in 1:N)...
+    )
+    refcall = Expr(:call, fname, kwparam, tname, ntuple(Returns(:Trivial), N)...)
+    hookcall = Expr(:call, :_symmetrize_operator, kwparam, refcall, tsyms...)
+    method_terminal = Expr(:(=), tsig, hookcall)
+
+    aliasdef = alias === nothing ? nothing : Expr(:const, Expr(:(=), alias, fname))
+
+    return esc(
+        quote
+            Core.@__doc__ $method_sym
+            $method_elt
+            $method_terminal
+            $aliasdef
+        end
+    )
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -9,6 +9,7 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 TensorKitTensors = "41b62e7d-e9d1-4e23-942c-79a97adf954b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 
 [sources]
 TensorKitTensors = {path = ".."}
@@ -18,3 +19,4 @@ Aqua = "0.8.9"
 ParallelTestRunner = "2"
 StableRNGs = "1"
 Test = "1"
+TestExtras = "0.3"

--- a/test/bosonoperators.jl
+++ b/test/bosonoperators.jl
@@ -19,6 +19,15 @@ using StableRNGs
     @test all(c -> block(N_big, c)[1] == big(c.charge), sectors(boson_space(U1Irrep; cutoff)))
 end
 
+@testset "type inference" begin
+    cutoff = 2
+
+    @test (@inferred b_num(; cutoff)) isa AbstractTensorMap
+    @test (@inferred b_num(Float64; cutoff)) isa AbstractTensorMap
+    @test (@inferred b_num(Float64, U1Irrep; cutoff)) isa AbstractTensorMap
+    @test (@inferred b_hopping(Float64, U1Irrep; cutoff)) isa AbstractTensorMap
+end
+
 @testset "Non-symmetric bosonic operators" begin
     cutoff = 4
 

--- a/test/bosonoperators.jl
+++ b/test/bosonoperators.jl
@@ -24,7 +24,9 @@ end
 
     @test (@inferred b_num(; cutoff)) isa AbstractTensorMap
     @test (@inferred b_num(Float64; cutoff)) isa AbstractTensorMap
+    @test (@inferred b_num(U1Irrep; cutoff)) isa AbstractTensorMap
     @test (@inferred b_num(Float64, U1Irrep; cutoff)) isa AbstractTensorMap
+    @test (@inferred b_hopping(U1Irrep; cutoff)) isa AbstractTensorMap
     @test (@inferred b_hopping(Float64, U1Irrep; cutoff)) isa AbstractTensorMap
 end
 

--- a/test/bosonoperators.jl
+++ b/test/bosonoperators.jl
@@ -22,27 +22,27 @@ end
 @testset "type inference" begin
     cutoff = 2
 
-    @test (@inferred b_num(; cutoff)) isa AbstractTensorMap
-    @test (@inferred b_num(Float64; cutoff)) isa AbstractTensorMap
-    @test (@inferred b_num(U1Irrep; cutoff)) isa AbstractTensorMap
-    @test (@inferred b_num(Float64, U1Irrep; cutoff)) isa AbstractTensorMap
-    @test (@inferred b_hopping(U1Irrep; cutoff)) isa AbstractTensorMap
-    @test (@inferred b_hopping(Float64, U1Irrep; cutoff)) isa AbstractTensorMap
+    @test (@testinferred b_num(; cutoff)) isa AbstractTensorMap
+    @test (@testinferred b_num(Float64; cutoff)) isa AbstractTensorMap
+    @test (@testinferred b_num(U1Irrep; cutoff)) isa AbstractTensorMap
+    @test (@testinferred b_num(Float64, U1Irrep; cutoff)) isa AbstractTensorMap
+    @test (@testinferred b_hopping(U1Irrep; cutoff)) isa AbstractTensorMap
+    @test (@testinferred b_hopping(Float64, U1Irrep; cutoff)) isa AbstractTensorMap
 end
 
 @testset "Non-symmetric bosonic operators" begin
     cutoff = 4
 
     # inferrability
-    B⁻ = @inferred b⁻(; cutoff)
-    B⁺ = @inferred b⁺(; cutoff)
-    N = @inferred n(; cutoff)
-    B⁻B⁻ = @inferred b⁻b⁻(; cutoff)
-    B⁺B⁻ = @inferred b⁺b⁻(; cutoff)
-    B⁻B⁺ = @inferred b⁻b⁺(; cutoff)
-    B⁺B⁺ = @inferred b⁺b⁺(; cutoff)
-    Bhop = @inferred b_hop(; cutoff)
-    V = @inferred boson_space(Trivial; cutoff)
+    B⁻ = @testinferred b⁻(; cutoff)
+    B⁺ = @testinferred b⁺(; cutoff)
+    N = @testinferred n(; cutoff)
+    B⁻B⁻ = @testinferred b⁻b⁻(; cutoff)
+    B⁺B⁻ = @testinferred b⁺b⁻(; cutoff)
+    B⁻B⁺ = @testinferred b⁻b⁺(; cutoff)
+    B⁺B⁺ = @testinferred b⁺b⁺(; cutoff)
+    Bhop = @testinferred b_hop(; cutoff)
+    V = @testinferred boson_space(Trivial; cutoff)
 
     # test adjoints
     @test B⁻' ≈ B⁺
@@ -73,10 +73,10 @@ end
     cutoff = 4
 
     # inferrability
-    N = @inferred n(U1Irrep; cutoff)
-    B⁺B⁻ = @inferred b⁺b⁻(U1Irrep; cutoff)
-    B⁻B⁺ = @inferred b⁻b⁺(U1Irrep; cutoff)
-    V = @inferred boson_space(U1Irrep; cutoff)
+    N = @testinferred n(U1Irrep; cutoff)
+    B⁺B⁻ = @testinferred b⁺b⁻(U1Irrep; cutoff)
+    B⁻B⁺ = @testinferred b⁻b⁺(U1Irrep; cutoff)
+    V = @testinferred boson_space(U1Irrep; cutoff)
 
     # non-symmetric operators throw error
     @test_throws ArgumentError b⁻(U1Irrep; cutoff)
@@ -97,10 +97,10 @@ end
     for symmetry in (Trivial, U1Irrep)
         rng = StableRNG(123)
         # inferrability
-        N = @inferred n(symmetry; cutoff)
-        B⁺B⁻ = @inferred b⁺b⁻(symmetry; cutoff)
-        B⁻B⁺ = @inferred b⁻b⁺(symmetry; cutoff)
-        V = @inferred boson_space(symmetry; cutoff)
+        N = @testinferred n(symmetry; cutoff)
+        B⁺B⁻ = @testinferred b⁺b⁻(symmetry; cutoff)
+        B⁻B⁺ = @testinferred b⁻b⁺(symmetry; cutoff)
+        V = @testinferred boson_space(symmetry; cutoff)
 
         b_pm, b_mp, b_n = rand(rng, 3)
         O = (N ⊗ id(V) + id(V) ⊗ N) * b_n + B⁻B⁺ * b_mp + B⁺B⁻ * b_pm

--- a/test/fermionoperators.jl
+++ b/test/fermionoperators.jl
@@ -23,12 +23,12 @@ const symmetries = (Trivial, U1Irrep)
 end
 
 @testset "type inference" begin
-    @test (@inferred f_num()) isa AbstractTensorMap
-    @test (@inferred f_num(Float64)) isa AbstractTensorMap
-    @test (@inferred f_num(U1Irrep)) isa AbstractTensorMap
-    @test (@inferred f_num(Float64, U1Irrep)) isa AbstractTensorMap
-    @test (@inferred f_hopping(U1Irrep)) isa AbstractTensorMap
-    @test (@inferred f_hopping(Float64, U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred f_num()) isa AbstractTensorMap
+    @test (@testinferred f_num(Float64)) isa AbstractTensorMap
+    @test (@testinferred f_num(U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred f_num(Float64, U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred f_hopping(U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred f_hopping(Float64, U1Irrep)) isa AbstractTensorMap
 end
 
 @testset "fermion properties" begin

--- a/test/fermionoperators.jl
+++ b/test/fermionoperators.jl
@@ -22,6 +22,13 @@ const symmetries = (Trivial, U1Irrep)
     @test scalartype(f_hopping(Complex{BigFloat}, U1Irrep)) === Complex{BigFloat}
 end
 
+@testset "type inference" begin
+    @test (@inferred f_num()) isa AbstractTensorMap
+    @test (@inferred f_num(Float64)) isa AbstractTensorMap
+    @test (@inferred f_num(Float64, U1Irrep)) isa AbstractTensorMap
+    @test (@inferred f_hopping(Float64, U1Irrep)) isa AbstractTensorMap
+end
+
 @testset "fermion properties" begin
     @test f⁻f⁻() ≈ -swap_2sites(f⁻f⁻())
     @test f⁺f⁺() ≈ -swap_2sites(f⁺f⁺())

--- a/test/fermionoperators.jl
+++ b/test/fermionoperators.jl
@@ -25,7 +25,9 @@ end
 @testset "type inference" begin
     @test (@inferred f_num()) isa AbstractTensorMap
     @test (@inferred f_num(Float64)) isa AbstractTensorMap
+    @test (@inferred f_num(U1Irrep)) isa AbstractTensorMap
     @test (@inferred f_num(Float64, U1Irrep)) isa AbstractTensorMap
+    @test (@inferred f_hopping(U1Irrep)) isa AbstractTensorMap
     @test (@inferred f_hopping(Float64, U1Irrep)) isa AbstractTensorMap
 end
 

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -45,8 +45,11 @@ end
 @testset "type inference" begin
     @test (@inferred e_num()) isa AbstractTensorMap
     @test (@inferred e_num(Float64)) isa AbstractTensorMap
+    @test (@inferred e_num(U1Irrep, U1Irrep)) isa AbstractTensorMap
     @test (@inferred e_num(Float64, U1Irrep, U1Irrep)) isa AbstractTensorMap
+    @test (@inferred e_hopping(U1Irrep, U1Irrep)) isa AbstractTensorMap
     @test (@inferred e_hopping(Float64, U1Irrep, U1Irrep)) isa AbstractTensorMap
+    @test (@inferred S_exchange(U1Irrep, SU2Irrep)) isa AbstractTensorMap
     @test (@inferred S_exchange(Float64, U1Irrep, SU2Irrep)) isa AbstractTensorMap
 end
 

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -42,6 +42,14 @@ has_triplet(P, S) = P === Trivial && S === Trivial
     @test all(((c, b),) -> all(isinteger, b), blocks(N_big))
 end
 
+@testset "type inference" begin
+    @test (@inferred e_num()) isa AbstractTensorMap
+    @test (@inferred e_num(Float64)) isa AbstractTensorMap
+    @test (@inferred e_num(Float64, U1Irrep, U1Irrep)) isa AbstractTensorMap
+    @test (@inferred e_hopping(Float64, U1Irrep, U1Irrep)) isa AbstractTensorMap
+    @test (@inferred S_exchange(Float64, U1Irrep, SU2Irrep)) isa AbstractTensorMap
+end
+
 @testset "Compare symmetric with trivial tensors" begin
     for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
         space = @inferred hubbard_space(particle_symmetry, spin_symmetry)

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -43,19 +43,19 @@ has_triplet(P, S) = P === Trivial && S === Trivial
 end
 
 @testset "type inference" begin
-    @test (@inferred e_num()) isa AbstractTensorMap
-    @test (@inferred e_num(Float64)) isa AbstractTensorMap
-    @test (@inferred e_num(U1Irrep, U1Irrep)) isa AbstractTensorMap
-    @test (@inferred e_num(Float64, U1Irrep, U1Irrep)) isa AbstractTensorMap
-    @test (@inferred e_hopping(U1Irrep, U1Irrep)) isa AbstractTensorMap
-    @test (@inferred e_hopping(Float64, U1Irrep, U1Irrep)) isa AbstractTensorMap
-    @test (@inferred S_exchange(U1Irrep, SU2Irrep)) isa AbstractTensorMap
-    @test (@inferred S_exchange(Float64, U1Irrep, SU2Irrep)) isa AbstractTensorMap
+    @test (@testinferred e_num()) isa AbstractTensorMap
+    @test (@testinferred e_num(Float64)) isa AbstractTensorMap
+    @test (@testinferred e_num(U1Irrep, U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred e_num(Float64, U1Irrep, U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred e_hopping(U1Irrep, U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred e_hopping(Float64, U1Irrep, U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred S_exchange(U1Irrep, SU2Irrep)) isa AbstractTensorMap
+    @test (@testinferred S_exchange(Float64, U1Irrep, SU2Irrep)) isa AbstractTensorMap
 end
 
 @testset "Compare symmetric with trivial tensors" begin
     for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
-        space = @inferred hubbard_space(particle_symmetry, spin_symmetry)
+        space = @testinferred hubbard_space(particle_symmetry, spin_symmetry)
         @test dim(space) == 4
 
         # element-wise comparison in the dense basis catches transposes and gauge errors

--- a/test/spinoperators.jl
+++ b/test/spinoperators.jl
@@ -47,7 +47,9 @@ end
 @testset "type inference" begin
     @test (@inferred S_z()) isa AbstractTensorMap
     @test (@inferred S_z(Float64)) isa AbstractTensorMap
+    @test (@inferred S_z(U1Irrep)) isa AbstractTensorMap
     @test (@inferred S_z(Float64, U1Irrep)) isa AbstractTensorMap
+    @test (@inferred S_exchange(SU2Irrep; spin = 1 // 2)) isa AbstractTensorMap
     @test (@inferred S_exchange(Float64, SU2Irrep; spin = 1 // 2)) isa AbstractTensorMap
 end
 

--- a/test/spinoperators.jl
+++ b/test/spinoperators.jl
@@ -45,27 +45,27 @@ end
 end
 
 @testset "type inference" begin
-    @test (@inferred S_z()) isa AbstractTensorMap
-    @test (@inferred S_z(Float64)) isa AbstractTensorMap
-    @test (@inferred S_z(U1Irrep)) isa AbstractTensorMap
-    @test (@inferred S_z(Float64, U1Irrep)) isa AbstractTensorMap
-    @test (@inferred S_exchange(SU2Irrep; spin = 1 // 2)) isa AbstractTensorMap
-    @test (@inferred S_exchange(Float64, SU2Irrep; spin = 1 // 2)) isa AbstractTensorMap
+    @test (@testinferred S_z()) isa AbstractTensorMap
+    @test (@testinferred S_z(Float64)) isa AbstractTensorMap
+    @test (@testinferred S_z(U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred S_z(Float64, U1Irrep)) isa AbstractTensorMap
+    @test (@testinferred S_exchange(SU2Irrep; spin = 1 // 2)) isa AbstractTensorMap
+    @test (@testinferred S_exchange(Float64, SU2Irrep; spin = 1 // 2)) isa AbstractTensorMap
 end
 
 @testset "Non-symmetric spin $spin operators" for spin in (1 // 2):(1 // 2):(5 // 2)
     # inferrability
-    X = @inferred S_x(; spin)
-    Y = @inferred S_y(; spin)
-    Z = @inferred S_z(; spin)
-    S⁺ = @inferred S_plus(; spin)
-    S⁻ = @inferred S_min(; spin)
-    S⁺S⁻ = @inferred S_plus_S_min(; spin)
-    S⁻S⁺ = @inferred S_min_S_plus(; spin)
-    XX = @inferred S_x_S_x(; spin)
-    YY = @inferred S_y_S_y(; spin)
-    ZZ = @inferred S_z_S_z(; spin)
-    SS = @inferred S_exchange(; spin)
+    X = @testinferred S_x(; spin)
+    Y = @testinferred S_y(; spin)
+    Z = @testinferred S_z(; spin)
+    S⁺ = @testinferred S_plus(; spin)
+    S⁻ = @testinferred S_min(; spin)
+    S⁺S⁻ = @testinferred S_plus_S_min(; spin)
+    S⁻S⁺ = @testinferred S_min_S_plus(; spin)
+    XX = @testinferred S_x_S_x(; spin)
+    YY = @testinferred S_y_S_y(; spin)
+    ZZ = @testinferred S_z_S_z(; spin)
+    SS = @testinferred S_exchange(; spin)
 
     # hermiticity, normalization, and su(2) commutation relations
     test_spin_algebra(X, Y, Z; spin)
@@ -88,11 +88,11 @@ end
 
 @testset "Z2-Symmetric spin 1//2 operators" begin
     # inferrability
-    X = @inferred S_x(Z2Irrep)
-    XX = @inferred S_x_S_x(Z2Irrep)
-    YY = @inferred S_y_S_y(Z2Irrep)
-    ZZ = @inferred S_z_S_z(Z2Irrep)
-    exchange = @inferred S_exchange(Z2Irrep)
+    X = @testinferred S_x(Z2Irrep)
+    XX = @testinferred S_x_S_x(Z2Irrep)
+    YY = @testinferred S_y_S_y(Z2Irrep)
+    ZZ = @testinferred S_z_S_z(Z2Irrep)
+    exchange = @testinferred S_exchange(Z2Irrep)
 
     @test_throws ArgumentError S_x(Z2Irrep; spin = 1)
     @test_throws ArgumentError S_x_S_x(Z2Irrep; spin = 1)
@@ -118,11 +118,11 @@ end
 
 @testset "U1-Symmetric spin $spin operators" for spin in (1 // 2):(1 // 2):(5 // 2)
     # inferrability
-    Z = @inferred S_z(U1Irrep; spin)
-    ZZ = @inferred S_z_S_z(U1Irrep; spin)
-    plusmin = @inferred S_plus_S_min(U1Irrep; spin)
-    minplus = @inferred S_min_S_plus(U1Irrep; spin)
-    exchange = @inferred S_exchange(U1Irrep; spin)
+    Z = @testinferred S_z(U1Irrep; spin)
+    ZZ = @testinferred S_z_S_z(U1Irrep; spin)
+    plusmin = @testinferred S_plus_S_min(U1Irrep; spin)
+    minplus = @testinferred S_min_S_plus(U1Irrep; spin)
+    exchange = @testinferred S_exchange(U1Irrep; spin)
 
     @test_throws ArgumentError S_x(U1Irrep; spin)
     @test_throws ArgumentError S_y(U1Irrep; spin)
@@ -140,8 +140,8 @@ end
 
 @testset "SU2-Symmetric spin $spin operators" for spin in (1 // 2):(1 // 2):(5 // 2)
     # inferrability
-    V = @inferred spin_space(SU2Irrep; spin)
-    SS = @inferred S_exchange(SU2Irrep; spin)
+    V = @testinferred spin_space(SU2Irrep; spin)
+    SS = @testinferred S_exchange(SU2Irrep; spin)
 
     @test_throws ArgumentError S_x(SU2Irrep; spin)
     @test_throws ArgumentError S_y(SU2Irrep; spin)
@@ -163,9 +163,9 @@ end
 @testset "Exact diagonalisation for $sector symmetry" for sector in [Trivial, U1Irrep]
     spin = 1
 
-    ZZ = @inferred S_z_S_z(sector; spin)
-    plusmin = @inferred S_plus_S_min(sector; spin)
-    minplus = @inferred S_min_S_plus(sector; spin)
+    ZZ = @testinferred S_z_S_z(sector; spin)
+    plusmin = @testinferred S_plus_S_min(sector; spin)
+    minplus = @testinferred S_min_S_plus(sector; spin)
     O = ZZ + 0.5 * (plusmin + minplus)
 
     true_eigenvals = vcat(-2.0, fill(-1.0, 3), fill(1.0, 5))

--- a/test/spinoperators.jl
+++ b/test/spinoperators.jl
@@ -44,6 +44,13 @@ end
     @test abs(block(SS, SU2Irrep(1))[1] - 1 // 4) < 1.0e-14
 end
 
+@testset "type inference" begin
+    @test (@inferred S_z()) isa AbstractTensorMap
+    @test (@inferred S_z(Float64)) isa AbstractTensorMap
+    @test (@inferred S_z(Float64, U1Irrep)) isa AbstractTensorMap
+    @test (@inferred S_exchange(Float64, SU2Irrep; spin = 1 // 2)) isa AbstractTensorMap
+end
+
 @testset "Non-symmetric spin $spin operators" for spin in (1 // 2):(1 // 2):(5 // 2)
     # inferrability
     X = @inferred S_x(; spin)

--- a/test/testsetup.jl
+++ b/test/testsetup.jl
@@ -2,8 +2,10 @@ module TensorKitTensorsTestSetup
 
 export test_operator, test_operator_dense, test_spin_algebra
 export swap_2sites, expanded_eigenvalues, operator_sum
+export @testinferred
 
 using Test
+using TestExtras: @testinferred
 using TensorKit
 using TensorKitTensors: desymmetrize
 using LinearAlgebra: eigvals, tr

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -10,13 +10,13 @@ particle_syms = (Trivial, U1Irrep)
 spin_syms = (Trivial, U1Irrep, SU2Irrep)
 
 @testset "type inference" begin
-    @test (@inferred S_exchange()) isa AbstractTensorMap
-    @test (@inferred S_exchange(U1Irrep, SU2Irrep)) isa AbstractTensorMap
-    @test (@inferred S_exchange(Float64, U1Irrep, SU2Irrep)) isa AbstractTensorMap
-    @test (@inferred S_exchange(U1Irrep, SU2Irrep; slave_fermion = true)) isa AbstractTensorMap
-    @test (@inferred S_exchange(Float64, U1Irrep, SU2Irrep; slave_fermion = true)) isa AbstractTensorMap
-    @test (@inferred e_hopping(U1Irrep, U1Irrep; slave_fermion = true)) isa AbstractTensorMap
-    @test (@inferred e_hopping(Float64, U1Irrep, U1Irrep; slave_fermion = true)) isa AbstractTensorMap
+    @test (@testinferred S_exchange()) isa AbstractTensorMap
+    @test (@testinferred S_exchange(U1Irrep, SU2Irrep)) isa AbstractTensorMap
+    @test (@testinferred S_exchange(Float64, U1Irrep, SU2Irrep)) isa AbstractTensorMap
+    @test (@testinferred S_exchange(U1Irrep, SU2Irrep; slave_fermion = true)) isa AbstractTensorMap
+    @test (@testinferred S_exchange(Float64, U1Irrep, SU2Irrep; slave_fermion = true)) isa AbstractTensorMap
+    @test (@testinferred e_hopping(U1Irrep, U1Irrep; slave_fermion = true)) isa AbstractTensorMap
+    @test (@testinferred e_hopping(Float64, U1Irrep, U1Irrep; slave_fermion = true)) isa AbstractTensorMap
 end
 
 @testset "Compare symmetric with trivial tensors" begin

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -11,8 +11,11 @@ spin_syms = (Trivial, U1Irrep, SU2Irrep)
 
 @testset "type inference" begin
     @test (@inferred S_exchange()) isa AbstractTensorMap
+    @test (@inferred S_exchange(U1Irrep, SU2Irrep)) isa AbstractTensorMap
     @test (@inferred S_exchange(Float64, U1Irrep, SU2Irrep)) isa AbstractTensorMap
+    @test (@inferred S_exchange(U1Irrep, SU2Irrep; slave_fermion = true)) isa AbstractTensorMap
     @test (@inferred S_exchange(Float64, U1Irrep, SU2Irrep; slave_fermion = true)) isa AbstractTensorMap
+    @test (@inferred e_hopping(U1Irrep, U1Irrep; slave_fermion = true)) isa AbstractTensorMap
     @test (@inferred e_hopping(Float64, U1Irrep, U1Irrep; slave_fermion = true)) isa AbstractTensorMap
 end
 

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -9,6 +9,13 @@ using StableRNGs
 particle_syms = (Trivial, U1Irrep)
 spin_syms = (Trivial, U1Irrep, SU2Irrep)
 
+@testset "type inference" begin
+    @test (@inferred S_exchange()) isa AbstractTensorMap
+    @test (@inferred S_exchange(Float64, U1Irrep, SU2Irrep)) isa AbstractTensorMap
+    @test (@inferred S_exchange(Float64, U1Irrep, SU2Irrep; slave_fermion = true)) isa AbstractTensorMap
+    @test (@inferred e_hopping(Float64, U1Irrep, U1Irrep; slave_fermion = true)) isa AbstractTensorMap
+end
+
 @testset "Compare symmetric with trivial tensors" begin
     L = 4
     for (particle_symmetry, spin_symmetry, slave_fermion) in Iterators.product(particle_syms, spin_syms, (false, true))


### PR DESCRIPTION
This PR centralizes the repeated operator boiler plate into a single common form, hopefully making things a bit more streamlined.
I know the actual linecount has increased, but this is mostly since I did try to add docstrings to the `@operator` macro, and the macro itself. I think it is still a slight improvement to have all of this code centralized, and to avoid the `@eval` loops.

## Changes

Adds a single `@operator` macro (`src/utils.jl`):

```julia
@operator [alias] op(::Type{<:Number}[=default], ::Type{<:Sector}[=default], …; kwargs...)
```

From the signature template it generates the default-argument forwarding
methods (reading the element-type constraint/default and each symmetry's
default) and the optional alias binding, so only the implementation method(s)
need to be written separately.