### PR TITLE
Make Format check safe for fork PRs (pull_request trigger)

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,14 +1,12 @@
 name: 'Format'
 
 on:
-  pull_request_target:
+  pull_request:
     paths: ['**/*.jl']
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
-  actions: write
-  pull-requests: write
 
 jobs:
   Runic:


### PR DESCRIPTION
Switches the Format workflow trigger from `pull_request_target` to
`pull_request` and drops the `actions: write` / `pull-requests: write`
permissions.

GitHub now refuses to check out fork PR code from a `pull_request_target`
workflow, which broke the formatting check for all external contributors
(PRs from forks). The reusable workflow has been reworked to run safely under a
read-only `pull_request` context and reports the formatting diff in the job
summary instead of commenting on the PR.

Depends on QuantumKitHub/QuantumKitHubActions#2 (the reusable workflow update),
which should be merged first since this references `FormatCheck.yml@main`.

Refs QuantumKitHub/.github#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)