### PR TITLE
Refactor TJOperators to the dense-first strategy

### DIFF
--- a/docs/src/tjoperators.md
+++ b/docs/src/tjoperators.md
@@ -1,9 +1,19 @@
 ```@meta
+CurrentModule = TensorKitTensors.TJOperators
 CollapsedDocStrings = true
 ```
 
 # TJ operators
 
+## Relation to the Hubbard model
+
+The t-J model is the Hubbard model restricted to the subspace without double occupancy. The
+operators of this module are defined accordingly: each of them is the projection of the
+[Hubbard operator](hubbardoperators.md) of the same name onto the t-J space, through the
+``3 ← 4`` isometry [`tj_projector`](@ref). The only Hubbard operators without a t-J
+counterpart are the double-occupancy operators `ud_num` and `half_ud_num`, which project to
+zero.
+
 ```@autodocs
-Modules = [TensorKitTensors.TJOperators]
+Modules = [TJOperators]
 ```

--- a/src/hubbardoperators.jl
+++ b/src/hubbardoperators.jl
@@ -193,7 +193,7 @@ end
     u_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     nꜛ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the one-body operator that counts the number of spin-up particles.
+Return the one-body operator that counts the number of spin-up electrons.
 """
 @operator nꜛ function u_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(1), elt)
@@ -207,7 +207,7 @@ end
     d_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     nꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the one-body operator that counts the number of spin-down particles.
+Return the one-body operator that counts the number of spin-down electrons.
 """
 @operator nꜜ function d_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(1), elt)
@@ -221,7 +221,7 @@ end
     e_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     n([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the one-body operator that counts the number of particles.
+Return the one-body operator that counts the number of electrons.
 """
 @operator n function e_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return u_num(elt, Trivial, Trivial) + d_num(elt, Trivial, Trivial)
@@ -240,7 +240,7 @@ end
 """
     half_ud_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the the one-body operator that is equivalent to `(nꜛ - 1/2)(nꜜ - 1/2)`, which respects the particle-hole symmetry.
+Return the one-body operator that is equivalent to `(nꜛ - 1/2)(nꜜ - 1/2)`, which respects the particle-hole symmetry.
 """
 @operator function half_ud_num(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     I = id(hubbard_space(Trivial, Trivial))
@@ -318,7 +318,7 @@ end
     u_plus_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     u⁺u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e†_{1,↑}, e_{2,↑}`` that creates a spin-up particle at the first site and annihilates a spin-up particle at the second.
+Return the two-body operator ``e†_{1,↑} e_{2,↑}`` that creates a spin-up electron at the first site and annihilates a spin-up electron at the second.
 """
 @operator u⁺u⁻ function u_plus_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
@@ -334,7 +334,7 @@ end
     d_plus_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     d⁺d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e†_{1,↓}, e_{2,↓}`` that creates a spin-down particle at the first site and annihilates a spin-down particle at the second.
+Return the two-body operator ``e†_{1,↓} e_{2,↓}`` that creates a spin-down electron at the first site and annihilates a spin-down electron at the second.
 """
 @operator d⁺d⁻ function d_plus_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
@@ -350,7 +350,7 @@ end
     u_min_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     u⁻u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e_{1,↑}, e†_{2,↑}`` that annihilates a spin-up particle at the first site and creates a spin-up particle at the second.
+Return the two-body operator ``e_{1,↑} e†_{2,↑}`` that annihilates a spin-up electron at the first site and creates a spin-up electron at the second.
 """
 @operator u⁻u⁺ function u_min_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(u_plus_u_min(elt, Trivial, Trivial)))
@@ -360,7 +360,7 @@ end
     d_min_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     d⁻d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e_{1,↓}, e†_{2,↓}`` that annihilates a spin-down particle at the first site and creates a spin-down particle at the second.
+Return the two-body operator ``e_{1,↓} e†_{2,↓}`` that annihilates a spin-down electron at the first site and creates a spin-down electron at the second.
 """
 @operator d⁻d⁺ function d_min_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(d_plus_d_min(elt, Trivial, Trivial)))
@@ -370,7 +370,7 @@ end
     e_plus_e_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     e⁺e⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator that creates a particle at the first site and annihilates a particle at the second.
+Return the two-body operator that creates an electron at the first site and annihilates an electron at the second.
 This is the sum of `u_plus_u_min` and `d_plus_d_min`.
 """
 @operator e⁺e⁻ function e_plus_e_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
@@ -381,7 +381,7 @@ end
     e_min_e_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     e⁻e⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator that annihilates a particle at the first site and creates a particle at the second.
+Return the two-body operator that annihilates an electron at the first site and creates an electron at the second.
 This is the sum of `u_min_u_plus` and `d_min_d_plus`.
 """
 @operator e⁻e⁺ function e_min_e_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
@@ -392,11 +392,12 @@ end
     e_hopping([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     e_hop([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator that describes a particle that hops between the first and the second site.
+Return the two-body operator that describes an electron that hops between the first and the second site.
 
-For `SU2Irrep` particle symmetry, the hopping operator is expressed in the staggered gauge
-``c_{j,σ} → i^j c_{j,σ}`` and requires a complex scalar type; see
-[`basis_transform`](@ref HubbardOperators.basis_transform) for details.
+!!! note "Staggered gauge for SU2Irrep particle symmetry"
+    The hopping operator is expressed in the staggered gauge ``c_{j,σ} → i^j c_{j,σ}`` and
+    requires a complex scalar type; see
+    [`basis_transform`](@ref HubbardOperators.basis_transform) for details.
 """
 @operator e_hop function e_hopping(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return e_plus_e_min(elt, Trivial, Trivial) - e_min_e_plus(elt, Trivial, Trivial)
@@ -406,12 +407,8 @@ end
     u_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     u⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up particle at the first site and a spin-down particle at the second site.
-The nonzero matrix elements are
-```
-    -|0,0⟩ ↤ |↑,↓⟩,     +|0,↑⟩ ↤ |↑,↑↓⟩,
-    +|↓,0⟩ ↤ |↑↓,↓⟩,    -|↓,↑⟩ ↤ |↑↓,↑↓⟩
-```
+Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up electron at the first site and a spin-down electron at the second site.
+This operator does not conserve the number of electrons, and is therefore only compatible with `Trivial` particle symmetry.
 """
 @operator u⁻d⁻ function u_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
@@ -427,7 +424,7 @@ end
     u_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     u⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that creates a spin-up particle at the first site and a spin-down particle at the second site.
+Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that creates a spin-up electron at the first site and a spin-down electron at the second site.
 """
 @operator u⁺d⁺ function u_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(u_min_d_min(elt, Trivial, Trivial)))
@@ -437,12 +434,8 @@ end
     d_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     d⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down particle at the first site and a spin-up particle at the second site.
-The nonzero matrix elements are
-```
-    -|0,0⟩ ↤ |↓,↑⟩,     -|0,↓⟩ ↤ |↓,↑↓⟩
-    -|↑,0⟩ ↤ |↑↓,↑⟩,    -|↑,↓⟩ ↤ |↑↓,↑↓⟩
-```
+Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down electron at the first site and a spin-up electron at the second site.
+This operator does not conserve the number of electrons, and is therefore only compatible with `Trivial` particle symmetry.
 """
 @operator d⁻u⁻ function d_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
@@ -458,7 +451,7 @@ end
     d_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     d⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down particle at the first site and a spin-up particle at the second site.
+Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down electron at the first site and a spin-up electron at the second site.
 """
 @operator d⁺u⁺ function d_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(d_min_u_min(elt, Trivial, Trivial)))
@@ -468,12 +461,8 @@ end
     u_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     u⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e_{1,↑} e_{2,↑}`` that annihilates a spin-up particle at both sites.
-The nonzero matrix elements are
-```
-    -|0,0⟩ ↤ |↑,↑⟩,     -|0,↓⟩ ↤ |↑,↑↓⟩
-    +|↓,0⟩ ↤ |↑↓,↑⟩,    +|↓,↓⟩ ↤ |↑↓,↑↓⟩
-```
+Return the two-body operator ``e_{1,↑} e_{2,↑}`` that annihilates a spin-up electron at both sites.
+This operator conserves neither the number of electrons nor ``S^z``, and is therefore only compatible with `Trivial` particle and spin symmetry.
 """
 @operator u⁻u⁻ function u_min_u_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
@@ -489,7 +478,7 @@ end
     u_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     u⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up particle at both sites.
+Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up electron at both sites.
 """
 @operator u⁺u⁺ function u_plus_u_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(u_min_u_min(elt, Trivial, Trivial)))
@@ -499,12 +488,8 @@ end
     d_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     d⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e_{1,↓} e_{2,↓}`` that annihilates a spin-down particle at both sites.
-The nonzero matrix elements are
-```
-    -|0,0⟩ ↤ |↓,↓⟩,     +|0,↑⟩ ↤ |↓,↑↓⟩
-    -|↑,0⟩ ↤ |↑↓,↓⟩,    +|↑,↑⟩ ↤ |↑↓,↑↓⟩
-```
+Return the two-body operator ``e_{1,↓} e_{2,↓}`` that annihilates a spin-down electron at both sites.
+This operator conserves neither the number of electrons nor ``S^z``, and is therefore only compatible with `Trivial` particle and spin symmetry.
 """
 @operator d⁻d⁻ function d_min_d_min(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     t = n_site_operator(Val(2), elt)
@@ -520,7 +505,7 @@ end
     d_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
     d⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
-Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down particle at both sites.
+Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down electron at both sites.
 """
 @operator d⁺d⁺ function d_plus_d_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return -copy(adjoint(d_min_d_min(elt, Trivial, Trivial)))
@@ -531,7 +516,7 @@ end
     singlet⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``,
-which creates the singlet state when acting on vaccum.
+which creates the singlet state when acting on vacuum.
 """
 @operator singlet⁺ function singlet_plus(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
     return (u_plus_d_plus(elt, Trivial, Trivial) - d_plus_u_plus(elt, Trivial, Trivial)) /
@@ -554,23 +539,24 @@ end
     Δ⁺ij_Δjk([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Returns the 3-site term ``O_{ijk} = Δ^†_{ij} Δ_{jk}``, where
-``Δ^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
+``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
 It describes the hopping of a singlet pair from bond `(j,k)`
 to a nearest neighbor bond `(i,j)` sharing site `j`.
+The indices are ordered as
+```
+            -5      -6
+        ┌---┴-------┴---┐
+        |     Δ_{jk}    |
+        └---┬-------┬---┘
+    -4      1       -3
+┌---┴-------┴---┐
+|    Δ†_{ij}    |
+└---┬-------┬---┘
+    -1      -2
+    i       j       k
+```
 """
 @operator Δ⁺ij_Δjk function singlet_plus_singlet_min_3site(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
-    #=
-                -5      -6
-            ┌---┴-------┴---┐
-            |     A_{jk}    |
-            └---┬-------┬---┘
-        -4      1       -3
-    ┌---┴-------┴---┐
-    |    A†_{ij}    |
-    └---┬-------┬---┘
-        -1      -2
-        i       j       k
-    =#
     singp = singlet_plus(elt, Trivial, Trivial)
     singm = singp'
     return @tensor t[-1 -2 -3; -4 -5 -6] := singp[-1 -2; -4 1] * singm[1 -3; -5 -6]
@@ -582,7 +568,7 @@ end
     Δ⁺ij_Δkl([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Returns the 4-site term ``O_{ijkl} = Δ^†_{ij} Δ_{kl}``, where
-``Δ^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
+``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
 It measures the singlet pair correlation between two bonds `(i,j)` and `(k,l)`.
 """
 @operator Δ⁺ij_Δkl function singlet_plus_singlet_min_4site(elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial})
@@ -617,6 +603,7 @@ end
 
 """
     S_exchange([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
+    SS([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}])
 
 Return the spin exchange operator S⋅S.
 """

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -257,18 +257,11 @@ _maybe_slave_fermion(O::AbstractTensorMap, slave_fermion::Bool) =
 
 # Operators
 # ---------
-# The operators of this module are the projections of the `HubbardOperators` operators of the
-# same name, so both the definitions and their docstrings are generated from a single registry
-# of `(name, alias)` entries, and the description of an operator is inherited from the docstring
-# of its Hubbard counterpart, which is the single source of truth. Keeping the name and its
-# alias in a single entry is deliberate: zipping two separate lists silently misaligned three
-# aliases in the past.
 
-const _OPERATOR_ARGS = "([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)"
-
-# signature block for both names, the description inherited from the Hubbard counterpart, and
-# the boilerplate that relates the operator to that counterpart and to the slave-fermion basis
+# Keeps the prose of a Hubbard docstring, regenerate the signature block with `slave_fermion`
+# drop admonitions (by convention Hubbard-only)
 function _operator_docstring(name::Symbol, alias::Symbol, hubbard_doc)
+    _OPERATOR_ARGS = "([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)"
     return string(
         "    ", name, _OPERATOR_ARGS, "\n",
         "    ", alias, _OPERATOR_ARGS, "\n\n",
@@ -286,10 +279,6 @@ end
 _docstring_text(doc::Base.Docs.DocStr) = join(doc.text)
 _docstring_text(doc) = string(doc)
 
-# Keep the prose of a Hubbard docstring, dropping the signature block -- which is regenerated
-# above, with the `slave_fermion` keyword -- as well as any admonition, which by convention
-# holds Hubbard-specific detail that does not carry over to the projected operator. The
-# signature block is indented in the raw docstring, and a fenced code block in the rendered one.
 _is_toplevel(line) = !isempty(strip(line)) && !startswith(line, ' ')
 function _inherit_description(docstring::AbstractString)
     lines = split(docstring, '\n')
@@ -314,45 +303,23 @@ function _inherit_description(docstring::AbstractString)
     return strip(join(description, '\n'))
 end
 
-const _OPERATORS = (
-    # single-site operators
-    (:u_num, :nꜛ),
-    (:d_num, :nꜜ),
-    (:e_num, :n),
-    (:h_num, :nʰ),
-    (:S_plus, :S⁺),
-    (:S_min, :S⁻),
-    (:S_x, :Sˣ),
-    (:S_y, :Sʸ),
-    (:S_z, :Sᶻ),
-    # two-site operators
-    (:u_plus_u_min, :u⁺u⁻),
-    (:d_plus_d_min, :d⁺d⁻),
-    (:u_min_u_plus, :u⁻u⁺),
-    (:d_min_d_plus, :d⁻d⁺),
-    (:e_plus_e_min, :e⁺e⁻),
-    (:e_min_e_plus, :e⁻e⁺),
-    (:e_hopping, :e_hop),
-    (:u_min_d_min, :u⁻d⁻),
-    (:u_plus_d_plus, :u⁺d⁺),
-    (:d_min_u_min, :d⁻u⁻),
-    (:d_plus_u_plus, :d⁺u⁺),
-    (:u_min_u_min, :u⁻u⁻),
-    (:u_plus_u_plus, :u⁺u⁺),
-    (:d_min_d_min, :d⁻d⁻),
-    (:d_plus_d_plus, :d⁺d⁺),
-    (:singlet_plus, :singlet⁺),
-    (:singlet_min, :singlet⁻),
-    (:singlet_plus_singlet_min_3site, :Δ⁺ij_Δjk),
-    (:singlet_plus_singlet_min_4site, :Δ⁺ij_Δkl),
-    (:S_plus_S_min, :S⁺S⁻),
-    (:S_min_S_plus, :S⁻S⁺),
-    (:S_exchange, :SS),
-)
-
-for (name, alias) in _OPERATORS
-    # the parentheses are required: a bare `@doc x` at the end of a line makes the parser
-    # attach the next expression as the one being documented
+for (name, alias) in [
+        # single-site operators
+        (:u_num, :nꜛ), (:d_num, :nꜜ), (:e_num, :n), (:h_num, :nʰ),
+        (:S_plus, :S⁺), (:S_min, :S⁻),
+        (:S_x, :Sˣ), (:S_y, :Sʸ), (:S_z, :Sᶻ),
+        # two-site operators
+        (:u_plus_u_min, :u⁺u⁻), (:d_plus_d_min, :d⁺d⁻),
+        (:u_min_u_plus, :u⁻u⁺), (:d_min_d_plus, :d⁻d⁺),
+        (:e_plus_e_min, :e⁺e⁻), (:e_min_e_plus, :e⁻e⁺), (:e_hopping, :e_hop),
+        (:u_min_d_min, :u⁻d⁻), (:u_plus_d_plus, :u⁺d⁺),
+        (:d_min_u_min, :d⁻u⁻), (:d_plus_u_plus, :d⁺u⁺),
+        (:u_min_u_min, :u⁻u⁻), (:u_plus_u_plus, :u⁺u⁺),
+        (:d_min_d_min, :d⁻d⁻), (:d_plus_d_plus, :d⁺d⁺),
+        (:singlet_plus, :singlet⁺), (:singlet_min, :singlet⁻),
+        (:singlet_plus_singlet_min_3site, :Δ⁺ij_Δjk), (:singlet_plus_singlet_min_4site, :Δ⁺ij_Δkl),
+        (:S_plus_S_min, :S⁺S⁻), (:S_min_S_plus, :S⁻S⁺), (:S_exchange, :SS),
+    ]
     hubbard_doc = @eval @doc(HubbardOperators.$name)
     @eval export $name, $alias
     @eval @doc $(_operator_docstring(name, alias, hubbard_doc)) @operator $alias function $name(

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -6,30 +6,9 @@ import ..HubbardOperators
 import ..TensorKitTensors: symmetrize, desymmetrize, fuse_local_operators, @operator
 
 export tj_space, basis_transform, tj_projector
-export e_num, u_num, d_num, h_num
-export S_x, S_y, S_z, S_plus, S_min
-export u_plus_u_min, d_plus_d_min
-export u_min_u_plus, d_min_d_plus
-export u_min_d_min, d_min_u_min
-export u_plus_d_plus, d_plus_u_plus
-export u_min_u_min, d_min_d_min
-export u_plus_u_plus, d_plus_d_plus
-export e_plus_e_min, e_min_e_plus, e_hopping
-export singlet_plus, singlet_min
-export singlet_plus_singlet_min_3site, singlet_plus_singlet_min_4site
-export S_plus_S_min, S_min_S_plus, S_exchange
-
-export nꜛ, nꜜ, nʰ, n
-export Sˣ, Sʸ, Sᶻ, S⁺, S⁻
-export u⁺u⁻, d⁺d⁻, u⁻u⁺, d⁻d⁺
-export u⁻d⁻, d⁻u⁻, u⁺d⁺, d⁺u⁺
-export u⁻u⁻, u⁺u⁺, d⁻d⁻, d⁺d⁺
-export e⁺e⁻, e⁻e⁺, e_hop
-export singlet⁺, singlet⁻
-export Δ⁺ij_Δjk, Δ⁺ij_Δkl
-export S⁻S⁺, S⁺S⁻, SS
-
 export transform_slave_fermion
+# the operator names and their aliases are exported by the generation loop at the bottom of
+# this file, from the `_OPERATORS` registry
 
 const _docs_basis_table = """
 ```
@@ -187,19 +166,24 @@ function _symmetrize_operator(
     )
 end
 
+# Relation to the Hubbard model
+# -----------------------------
 """
     tj_projector(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 
 Projection operator from Hubbard space to t-J space, which removes the doubly occupied state
-``|↑↓⟩``. The t-J operators of this module are related to their `HubbardOperators`
-counterparts by
+``|↑↓⟩``. The operators of this module are *defined* as the projections of their
+`HubbardOperators` counterparts of the same name, i.e. they satisfy
 
 ```julia
 proj = reduce(⊗, ntuple(Returns(tj_projector(P, S)), N))
 TJOperators.op(elt, P, S) ≈ proj * HubbardOperators.op(elt, P, S) * proj'
 ```
 
-for an `N`-site operator `op`. The scalartype is `Int` to avoid floating point errors.
+for an `N`-site operator `op`. The double-occupancy operators of the Hubbard model
+(`ud_num` and `half_ud_num`) have no t-J counterpart, as they project to zero.
+
+The scalartype is `Int` to avoid floating point errors.
 """
 function tj_projector(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
     Vhub = HubbardOperators.hubbard_space(particle_symmetry, spin_symmetry)
@@ -213,6 +197,18 @@ function tj_projector(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:S
         proj[f1, f2][diagind(proj[f1, f2])] .= 1
     end
     return proj
+end
+
+# Project a Hubbard reference operator onto the t-J space, and express it in the requested
+# basis. The projector is parity-even, so it distributes over `⊗` and projecting the reference
+# operator is equivalent to projecting the symmetric one. Since it has integer entries, the
+# scalar type of the Hubbard operator is preserved.
+function _project_hubbard(O::AbstractTensorMap, slave_fermion::Bool)
+    Pⁿ = _reference_projector(Val(numout(O)))
+    return _maybe_slave_fermion(Pⁿ * O * Pⁿ', slave_fermion)
+end
+function _reference_projector(::Val{N}) where {N}
+    return reduce(⊗, ntuple(Returns(tj_projector(Trivial, Trivial)), Val(N)))
 end
 
 # Slave-fermion basis
@@ -253,538 +249,251 @@ function transform_slave_fermion(V::ElementarySpace)
     return fuse(V, V_aux)
 end
 
-# Express a reference operator in the requested basis. Reference operators are always built up
-# from single-site and multi-site operators in the plain t-J basis, and transformed only once,
-# at the very end: the slave-fermion transformation does not distribute over `⊗`.
+# Express a reference operator in the requested basis. Reference operators are always obtained
+# in the plain t-J basis, and transformed only once, at the very end: the slave-fermion
+# transformation does not distribute over `⊗`.
 _maybe_slave_fermion(O::AbstractTensorMap, slave_fermion::Bool) =
     slave_fermion ? transform_slave_fermion(O) : O
 
-function n_site_operator(::Val{N}, elt::Type{<:Number}) where {N}
-    V = tj_space(Trivial, Trivial)
-    return zeros(elt, V^N ← V^N)
+# Operators
+# ---------
+# The operators of this module are the projections of the `HubbardOperators` operators of the
+# same name, so both the definitions and their docstrings are generated from a single registry
+# of `(name, alias, description)` entries. Keeping the name and its alias in a single entry is
+# deliberate: zipping two separate lists silently misaligned three aliases in the past.
+
+const _OPERATOR_ARGS = "([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)"
+
+# signature block for both names, the operator-specific description, and the boilerplate that
+# relates the operator to its Hubbard counterpart and to the slave-fermion basis
+function _operator_docstring(name::Symbol, alias::Symbol, description::AbstractString)
+    return string(
+        "    ", name, _OPERATOR_ARGS, "\n",
+        "    ", alias, _OPERATOR_ARGS, "\n\n",
+        strip(description), "\n\n",
+        "This operator is the projection of `HubbardOperators.", name, "` onto the t-J space, ",
+        "see [`tj_projector`](@ref). Use `slave_fermion = true` to obtain it in the ",
+        "slave-fermion basis, see [`transform_slave_fermion`](@ref).\n",
+    )
 end
 
-# Single-site operators
-# ---------------------
-"""
-    u_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    nꜛ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+const _OPERATORS = (
+    # single-site operators
+    (
+        :u_num, :nꜛ, """
+        Return the one-body operator that counts the number of spin-up electrons.
+        """,
+    ),
+    (
+        :d_num, :nꜜ, """
+        Return the one-body operator that counts the number of spin-down electrons.
+        """,
+    ),
+    (
+        :e_num, :n, """
+        Return the one-body operator that counts the number of electrons.
+        """,
+    ),
+    (
+        :h_num, :nʰ, """
+        Return the one-body operator that counts the number of holes, i.e. the number of non-occupied sites.
+        """,
+    ),
+    (
+        :S_plus, :S⁺, """
+        Return the spin-plus operator `S⁺ = e†_↑ e_↓` (only compatible with `Trivial` spin symmetry).
+        """,
+    ),
+    (
+        :S_min, :S⁻, """
+        Return the spin-minus operator `S⁻ = e†_↓ e_↑` (only compatible with `Trivial` spin symmetry).
+        """,
+    ),
+    (
+        :S_x, :Sˣ, """
+        Return the one-body spin-1/2 x-operator on the electrons (only compatible with `Trivial` spin symmetry).
+        """,
+    ),
+    (
+        :S_y, :Sʸ, """
+        Return the one-body spin-1/2 y-operator on the electrons (only compatible with `Trivial` spin symmetry).
+        This operator requires a complex scalar type.
+        """,
+    ),
+    (
+        :S_z, :Sᶻ, """
+        Return the one-body spin-1/2 z-operator on the electrons.
+        """,
+    ),
+    # two-site operators
+    (
+        :u_plus_u_min, :u⁺u⁻, """
+        Return the two-body operator ``e†_{1,↑} e_{2,↑}`` that creates a spin-up electron at the first site and annihilates a spin-up electron at the second.
+        The only nonzero matrix element is
+        ```
+            +|↑,0⟩ ↤ |0,↑⟩
+        ```
+        """,
+    ),
+    (
+        :d_plus_d_min, :d⁺d⁻, """
+        Return the two-body operator ``e†_{1,↓} e_{2,↓}`` that creates a spin-down electron at the first site and annihilates a spin-down electron at the second.
+        The only nonzero matrix element is
+        ```
+            +|↓,0⟩ ↤ |0,↓⟩
+        ```
+        """,
+    ),
+    (
+        :u_min_u_plus, :u⁻u⁺, """
+        Return the two-body operator ``e_{1,↑} e†_{2,↑}`` that annihilates a spin-up electron at the first site and creates a spin-up electron at the second.
+        """,
+    ),
+    (
+        :d_min_d_plus, :d⁻d⁺, """
+        Return the two-body operator ``e_{1,↓} e†_{2,↓}`` that annihilates a spin-down electron at the first site and creates a spin-down electron at the second.
+        """,
+    ),
+    (
+        :e_plus_e_min, :e⁺e⁻, """
+        Return the two-body operator that creates an electron at the first site and annihilates an electron at the second.
+        This is the sum of `u_plus_u_min` and `d_plus_d_min`.
+        """,
+    ),
+    (
+        :e_min_e_plus, :e⁻e⁺, """
+        Return the two-body operator that annihilates an electron at the first site and creates an electron at the second.
+        This is the sum of `u_min_u_plus` and `d_min_d_plus`.
+        """,
+    ),
+    (
+        :e_hopping, :e_hop, """
+        Return the two-body operator that describes an electron that hops between the first and the second site.
+        """,
+    ),
+    (
+        :u_min_d_min, :u⁻d⁻, """
+        Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up electron at the first site and a spin-down electron at the second site.
+        The only nonzero matrix element is
+        ```
+            -|0,0⟩ ↤ |↑,↓⟩
+        ```
+        This operator does not conserve the number of electrons, and is therefore only compatible with `Trivial` particle symmetry.
+        """,
+    ),
+    (
+        :u_plus_d_plus, :u⁺d⁺, """
+        Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that creates a spin-up electron at the first site and a spin-down electron at the second site.
+        """,
+    ),
+    (
+        :d_min_u_min, :d⁻u⁻, """
+        Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down electron at the first site and a spin-up electron at the second site.
+        The only nonzero matrix element is
+        ```
+            -|0,0⟩ ↤ |↓,↑⟩
+        ```
+        This operator does not conserve the number of electrons, and is therefore only compatible with `Trivial` particle symmetry.
+        """,
+    ),
+    (
+        :d_plus_u_plus, :d⁺u⁺, """
+        Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down electron at the first site and a spin-up electron at the second site.
+        """,
+    ),
+    (
+        :u_min_u_min, :u⁻u⁻, """
+        Return the two-body operator ``e_{1,↑} e_{2,↑}`` that annihilates a spin-up electron at both sites.
+        The only nonzero matrix element is
+        ```
+            -|0,0⟩ ↤ |↑,↑⟩
+        ```
+        This operator conserves neither the number of electrons nor ``S^z``, and is therefore only compatible with `Trivial` particle and spin symmetry.
+        """,
+    ),
+    (
+        :u_plus_u_plus, :u⁺u⁺, """
+        Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up electron at both sites.
+        """,
+    ),
+    (
+        :d_min_d_min, :d⁻d⁻, """
+        Return the two-body operator ``e_{1,↓} e_{2,↓}`` that annihilates a spin-down electron at both
+        sites. The only nonzero matrix element is
+        ```
+            -|0,0⟩ ↤ |↓,↓⟩
+        ```
+        This operator conserves neither the number of electrons nor ``S^z``, and is therefore only
+        compatible with `Trivial` particle and spin symmetry.
+        """,
+    ),
+    (
+        :d_plus_d_plus, :d⁺d⁺, """
+        Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down electron at both sites.
+        """,
+    ),
+    (
+        :singlet_plus, :singlet⁺, """
+        Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``, which creates the singlet state when acting on vacuum.
+        """,
+    ),
+    (
+        :singlet_min, :singlet⁻, """
+        Return the adjoint of `singlet_plus` operator, which is ``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / \\sqrt{2}``.
+        """,
+    ),
+    (
+        :singlet_plus_singlet_min_3site, :Δ⁺ij_Δjk, """
+        Returns the 3-site term ``O_{ijk} = Δ^†_{ij} Δ_{jk}``, where ``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
+        It describes the hopping of a singlet pair from bond `(j,k)` to a nearest neighbor bond `(i,j)` sharing site `j`.
+        The indices are ordered as
+        ```
+                    -5      -6
+                ┌---┴-------┴---┐
+                |     Δ_{jk}    |
+                └---┬-------┬---┘
+            -4      1       -3
+        ┌---┴-------┴---┐
+        |    Δ†_{ij}    |
+        └---┬-------┬---┘
+            -1      -2
+            i       j       k
+        ```
+        """,
+    ),
+    (
+        :singlet_plus_singlet_min_4site, :Δ⁺ij_Δkl, """
+        Returns the 4-site term ``O_{ijkl} = Δ^†_{ij} Δ_{kl}``, where ``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
+        It measures the singlet pair correlation between two bonds `(i,j)` and `(k,l)`.
+        """,
+    ),
+    (
+        :S_plus_S_min, :S⁺S⁻, """
+        Return the two-body operator S⁺S⁻.
+        The only nonzero matrix element corresponds to `|↑,↓⟩ <-- |↓,↑⟩`.
+        """,
+    ),
+    (
+        :S_min_S_plus, :S⁻S⁺, """
+        Return the two-body operator S⁻S⁺.
+        The only nonzero matrix element corresponds to `|↓,↑⟩ <-- |↑,↓⟩`.
+        """,
+    ),
+    (
+        :S_exchange, :SS, """
+        Return the spin exchange operator S⋅S.
+        """,
+    ),
+)
 
-Return the one-body operator that counts the number of spin-up electrons.
-"""
-@operator nꜛ function u_num(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(1), elt)
-    I = sectortype(t)
-    t[(I(1), I(1))][1, 1] = 1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    d_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    nꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the one-body operator that counts the number of spin-down electrons.
-"""
-@operator nꜜ function d_num(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(1), elt)
-    I = sectortype(t)
-    t[(I(1), I(1))][2, 2] = 1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    e_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    n([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the one-body operator that counts the number of electrons.
-"""
-@operator n function e_num(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = u_num(elt, Trivial, Trivial) + d_num(elt, Trivial, Trivial)
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    h_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    nʰ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the one-body operator that counts the number of holes, i.e. the number of
-non-occupied sites.
-"""
-@operator nʰ function h_num(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = id(elt, tj_space(Trivial, Trivial)) - e_num(elt, Trivial, Trivial)
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the spin-plus operator `S⁺ = e†_↑ e_↓` (only compatible with `Trivial` spin symmetry).
-"""
-@operator S⁺ function S_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(1), elt)
-    I = sectortype(t)
-    t[(I(1), I(1))][1, 2] = 1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the spin-minus operator `S⁻ = e†_↓ e_↑` (only compatible with `Trivial` spin symmetry).
-"""
-@operator S⁻ function S_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = copy(adjoint(S_plus(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    S_x([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    Sˣ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the one-body spin-1/2 x-operator on the electrons (only compatible with `Trivial` spin symmetry).
-"""
-@operator Sˣ function S_x(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = (S_plus(elt, Trivial, Trivial) + S_min(elt, Trivial, Trivial)) / 2
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    S_y([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    Sʸ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the one-body spin-1/2 y-operator on the electrons (only compatible with `Trivial` spin symmetry).
-"""
-@operator Sʸ function S_y(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    # explicit error to avoid infinite recursion:
-    elt <: Real && throw(ArgumentError("S_y requires `elt <: Complex`"))
-    t = (S_plus(elt, Trivial, Trivial) - S_min(elt, Trivial, Trivial)) / (2im)
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    S_z([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    Sᶻ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the one-body spin-1/2 z-operator on the electrons.
-"""
-@operator Sᶻ function S_z(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = (u_num(elt, Trivial, Trivial) - d_num(elt, Trivial, Trivial)) / 2
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-# Two site operators
-# ------------------
-"""
-    u_plus_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    u⁺u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e†_{1,↑} e_{2,↑}`` that creates a spin-up electron at the
-first site and annihilates a spin-up electron at the second. The only nonzero matrix element is
-```
-    +|↑,0⟩ ↤ |0,↑⟩
-```
-"""
-@operator u⁺u⁻ function u_plus_u_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(2), elt)
-    I = sectortype(t)
-    t[(I(1), I(0), dual(I(0)), dual(I(1)))][1, 1, 1, 1] = 1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    d_plus_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    d⁺d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e†_{1,↓} e_{2,↓}`` that creates a spin-down electron at the
-first site and annihilates a spin-down electron at the second. The only nonzero matrix element is
-```
-    +|↓,0⟩ ↤ |0,↓⟩
-```
-"""
-@operator d⁺d⁻ function d_plus_d_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(2), elt)
-    I = sectortype(t)
-    t[(I(1), I(0), dual(I(0)), dual(I(1)))][2, 1, 1, 2] = 1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    u_min_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    u⁻u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e_{1,↑} e†_{2,↑}`` that annihilates a spin-up electron at the
-first site and creates a spin-up electron at the second.
-"""
-@operator u⁻u⁺ function u_min_u_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = -copy(adjoint(u_plus_u_min(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    d_min_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    d⁻d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e_{1,↓} e†_{2,↓}`` that annihilates a spin-down electron at the
-first site and creates a spin-down electron at the second.
-"""
-@operator d⁻d⁺ function d_min_d_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = -copy(adjoint(d_plus_d_min(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    e_plus_e_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    e⁺e⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator that creates an electron at the first site and annihilates an
-electron at the second. This is the sum of `u_plus_u_min` and `d_plus_d_min`.
-"""
-@operator e⁺e⁻ function e_plus_e_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = u_plus_u_min(elt, Trivial, Trivial) + d_plus_d_min(elt, Trivial, Trivial)
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    e_min_e_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    e⁻e⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator that annihilates an electron at the first site and creates an
-electron at the second. This is the sum of `u_min_u_plus` and `d_min_d_plus`.
-"""
-@operator e⁻e⁺ function e_min_e_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = -copy(adjoint(e_plus_e_min(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    e_hopping([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    e_hop([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator that describes an electron that hops between the first and the
-second site.
-"""
-@operator e_hop function e_hopping(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = e_plus_e_min(elt, Trivial, Trivial) - e_min_e_plus(elt, Trivial, Trivial)
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    u_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    u⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up electron at the
-first site and a spin-down electron at the second site. The only nonzero matrix element is
-```
-    -|0,0⟩ ↤ |↑,↓⟩
-```
-This operator does not conserve the number of electrons, and is therefore only compatible
-with `Trivial` particle symmetry.
-"""
-@operator u⁻d⁻ function u_min_d_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(2), elt)
-    I = sectortype(t)
-    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 2] = -1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    u_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    u⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that creates a spin-up electron at the
-first site and a spin-down electron at the second site.
-"""
-@operator u⁺d⁺ function u_plus_d_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = -copy(adjoint(u_min_d_min(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    d_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    d⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down electron at the
-first site and a spin-up electron at the second site. The only nonzero matrix element is
-```
-    -|0,0⟩ ↤ |↓,↑⟩
-```
-This operator does not conserve the number of electrons, and is therefore only compatible
-with `Trivial` particle symmetry.
-"""
-@operator d⁻u⁻ function d_min_u_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(2), elt)
-    I = sectortype(t)
-    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 1] = -1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    d_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    d⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down electron at the
-first site and a spin-up electron at the second site.
-"""
-@operator d⁺u⁺ function d_plus_u_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = -copy(adjoint(d_min_u_min(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    u_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    u⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e_{1,↑} e_{2,↑}`` that annihilates a spin-up electron at both
-sites. The only nonzero matrix element is
-```
-    -|0,0⟩ ↤ |↑,↑⟩
-```
-This operator conserves neither the number of electrons nor ``S^z``, and is therefore only
-compatible with `Trivial` particle and spin symmetry.
-"""
-@operator u⁻u⁻ function u_min_u_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(2), elt)
-    I = sectortype(t)
-    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 1] = -1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    u_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    u⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up electron at both sites.
-"""
-@operator u⁺u⁺ function u_plus_u_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = -copy(adjoint(u_min_u_min(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    d_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    d⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e_{1,↓} e_{2,↓}`` that annihilates a spin-down electron at both
-sites. The only nonzero matrix element is
-```
-    -|0,0⟩ ↤ |↓,↓⟩
-```
-This operator conserves neither the number of electrons nor ``S^z``, and is therefore only
-compatible with `Trivial` particle and spin symmetry.
-"""
-@operator d⁻d⁻ function d_min_d_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(2), elt)
-    I = sectortype(t)
-    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 2] = -1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    d_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    d⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down electron at both sites.
-"""
-@operator d⁺d⁺ function d_plus_d_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = -copy(adjoint(d_min_d_min(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    singlet_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    singlet⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``,
-which creates the singlet state when acting on vacuum.
-"""
-@operator singlet⁺ function singlet_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = (u_plus_d_plus(elt, Trivial, Trivial) - d_plus_u_plus(elt, Trivial, Trivial)) /
-        sqrt(2)
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    singlet_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    singlet⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the adjoint of `singlet_plus` operator, which is
-``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / \\sqrt{2}``.
-"""
-@operator singlet⁻ function singlet_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = copy(adjoint(singlet_plus(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    singlet_plus_singlet_min_3site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    Δ⁺ij_Δjk([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Returns the 3-site term ``O_{ijk} = Δ^†_{ij} Δ_{jk}``, where ``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
-It describes the hopping of a singlet pair from bond `(j,k)` to a nearest neighbor bond `(i,j)` sharing site `j`.
-"""
-@operator Δ⁺ij_Δjk function singlet_plus_singlet_min_3site(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    #=
-                -5      -6
-            ┌---┴-------┴---┐
-            |     A_{jk}    |
-            └---┬-------┬---┘
-        -4      1       -3
-    ┌---┴-------┴---┐
-    |    A†_{ij}    |
-    └---┬-------┬---┘
-        -1      -2
-        i       j       k
-    =#
-    singp = singlet_plus(elt, Trivial, Trivial)
-    singm = singp'
-    @tensor t[-1 -2 -3; -4 -5 -6] := singp[-1 -2; -4 1] * singm[1 -3; -5 -6]
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    singlet_plus_singlet_min_4site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    Δ⁺ij_Δkl([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Returns the 4-site term ``O_{ijkl} = Δ^†_{ij} Δ_{kl}``, where ``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
-It measures the singlet pair correlation between two bonds `(i,j)` and `(k,l)`.
-"""
-@operator Δ⁺ij_Δkl function singlet_plus_singlet_min_4site(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    singp = singlet_plus(elt, Trivial, Trivial)
-    return _maybe_slave_fermion(singp ⊗ singp', slave_fermion)
-end
-
-"""
-    S_plus_S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    S⁺S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator S⁺S⁻.
-The only nonzero matrix element corresponds to `|↑,↓⟩ <-- |↓,↑⟩`.
-"""
-@operator S⁺S⁻ function S_plus_S_min(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = n_site_operator(Val(2), elt)
-    I = sectortype(t)
-    t[(I(1), I(1), dual(I(1)), dual(I(1)))][1, 2, 2, 1] = 1
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    S_min_S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    S⁻S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the two-body operator S⁻S⁺.
-The only nonzero matrix element corresponds to `|↓,↑⟩ <-- |↑,↓⟩`.
-"""
-@operator S⁻S⁺ function S_min_S_plus(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    t = copy(adjoint(S_plus_S_min(elt, Trivial, Trivial)))
-    return _maybe_slave_fermion(t, slave_fermion)
-end
-
-"""
-    S_exchange([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-    SS([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
-
-Return the spin exchange operator S⋅S.
-"""
-@operator SS function S_exchange(
-        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
-        slave_fermion::Bool = false
-    )
-    Sz = S_z(elt, Trivial, Trivial)
-    t = Sz ⊗ Sz +
-        (S_plus_S_min(elt, Trivial, Trivial) + S_min_S_plus(elt, Trivial, Trivial)) / 2
-    return _maybe_slave_fermion(t, slave_fermion)
+for (name, alias, description) in _OPERATORS
+    @eval export $name, $alias
+    @eval @doc $(_operator_docstring(name, alias, description)) @operator $alias function $name(
+            elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+            slave_fermion::Bool = false
+        )
+        return _project_hubbard(HubbardOperators.$name(elt, Trivial, Trivial), slave_fermion)
+    end
 end
 
 end

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -3,9 +3,9 @@ module TJOperators
 using LinearAlgebra: diagind
 using TensorKit
 import ..HubbardOperators
-import ..TensorKitTensors: fuse_local_operators
+import ..TensorKitTensors: symmetrize, desymmetrize, fuse_local_operators, @operator
 
-export tj_space, tj_projector
+export tj_space, basis_transform, tj_projector
 export e_num, u_num, d_num, h_num
 export S_x, S_y, S_z, S_plus, S_min
 export u_plus_u_min, d_plus_d_min
@@ -41,8 +41,10 @@ const _docs_basis_table = """
 ```
 """
 
+# Spaces
+# ------
 @doc """
-    tj_space(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+    tj_space([particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
 
 Return the local hilbert space for a t-J-type model with the given particle and spin symmetries.
 The basis consists of the following states:
@@ -56,127 +58,165 @@ $_docs_basis_table
 The possible symmetries are:
 - Particle number : `Trivial`, `U1Irrep`
 - Spin            : `Trivial`, `U1Irrep`, `SU2Irrep`.
+
+Use `slave_fermion = true` to switch to the slave-fermion basis, which flips the fermion
+parity of every state; see [`transform_slave_fermion`](@ref).
 """ tj_space
 function tj_space(
+        particle_symmetry::Type{<:Sector} = Trivial,
+        spin_symmetry::Type{<:Sector} = Trivial;
+        slave_fermion::Bool = false
+    )
+    V = _tj_space(particle_symmetry, spin_symmetry)
+    return slave_fermion ? transform_slave_fermion(V) : V
+end
+
+# the t-J space in the plain basis; dispatched on the symmetries, with the `slave_fermion`
+# keyword handled once by `tj_space` above
+_tj_space(::Type{Trivial}, ::Type{Trivial}) = Vect[FermionParity](0 => 1, 1 => 2)
+function _tj_space(::Type{Trivial}, ::Type{U1Irrep})
+    return Vect[FermionParity ⊠ U1Irrep]((0, 0) => 1, (1, 1 // 2) => 1, (1, -1 // 2) => 1)
+end
+function _tj_space(::Type{Trivial}, ::Type{SU2Irrep})
+    return Vect[FermionParity ⊠ SU2Irrep]((0, 0) => 1, (1, 1 // 2) => 1)
+end
+function _tj_space(::Type{U1Irrep}, ::Type{Trivial})
+    return Vect[FermionParity ⊠ U1Irrep]((0, 0) => 1, (1, 1) => 2)
+end
+function _tj_space(::Type{U1Irrep}, ::Type{U1Irrep})
+    return Vect[FermionParity ⊠ U1Irrep ⊠ U1Irrep](
+        (0, 0, 0) => 1, (1, 1, 1 // 2) => 1, (1, 1, -1 // 2) => 1
+    )
+end
+function _tj_space(::Type{U1Irrep}, ::Type{SU2Irrep})
+    return Vect[FermionParity ⊠ U1Irrep ⊠ SU2Irrep]((0, 0, 0) => 1, (1, 1, 1 // 2) => 1)
+end
+# the η-pairing doublet of the Hubbard model is (|↑↓⟩, |0⟩), which has no t-J counterpart
+function _tj_space(::Type{SU2Irrep}, spin_symmetry::Type{<:Sector})
+    throw(ArgumentError("t-J model does not have ``SU(2)`` particle symmetry."))
+end
+function _tj_space(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    throw(ArgumentError("invalid symmetry `($particle_symmetry, $spin_symmetry)`"))
+end
+
+"""
+    basis_transform(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)
+
+Return the unitary basis transformation that maps the basis of
+`tj_space(Trivial, Trivial; slave_fermion)` onto the basis of
+`tj_space(particle_symmetry, spin_symmetry; slave_fermion)`, as a `TensorMap` between the
+desymmetrized versions of these spaces (see
+[`desymmetrize`](@ref TensorKitTensors.desymmetrize)), as required by
+[`symmetrize`](@ref TensorKitTensors.symmetrize).
+
+For all symmetry combinations the transformation is a permutation, determined by the sector
+order of the target space, where the states are identified as follows:
+
+- For `U1Irrep` particle symmetry, the number of electrons is used as charge, distinguishing
+  ``|0⟩`` (charge 0) from ``|↑⟩`` and ``|↓⟩`` (charge 1).
+- For `U1Irrep` spin symmetry, the ``S^z`` eigenvalue ``±1/2`` is used as charge,
+  distinguishing ``|↑⟩`` from ``|↓⟩``.
+- For `SU2Irrep` spin symmetry, ``(|↑⟩, |↓⟩)`` forms the spin doublet (descending ``m``).
+
+Both bases order the states by fermion parity, so the reference basis differs between them:
+
+```
+| basis          | reference order |
+| -------------- | --------------- |
+| t-J            | |0⟩, |↑⟩, |↓⟩   |
+| slave-fermion  | |↑⟩, |↓⟩, |0⟩   |
+```
+
+The transformations have exact integer entries and are therefore returned with integer
+scalar type, such that they promote to any scalar type without loss of precision.
+"""
+function basis_transform(
         particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
         slave_fermion::Bool = false
     )
-    V = if particle_symmetry === Trivial
-        if spin_symmetry === Trivial
-            Vect[FermionParity](0 => 1, 1 => 2)
-        elseif spin_symmetry === U1Irrep
-            Vect[FermionParity ⊠ U1Irrep]((0, 0) => 1, (1, 1 // 2) => 1, (1, -1 // 2) => 1)
-        elseif spin_symmetry === SU2Irrep
-            Vect[FermionParity ⊠ SU2Irrep]((0, 0) => 1, (1, 1 // 2) => 1)
-        else
-            throw(ArgumentError("Invalid symmetry"))
-        end
-    elseif particle_symmetry === U1Irrep
-        if spin_symmetry === Trivial
-            Vect[FermionParity ⊠ U1Irrep]((0, 0) => 1, (1, 1) => 2)
-        elseif spin_symmetry === U1Irrep
-            Vect[FermionParity ⊠ U1Irrep ⊠ U1Irrep]((0, 0, 0) => 1, (1, 1, 1 // 2) => 1, (1, 1, -1 // 2) => 1)
-        elseif spin_symmetry === SU2Irrep
-            Vect[FermionParity ⊠ U1Irrep ⊠ SU2Irrep]((0, 0, 0) => 1, (1, 1, 1 // 2) => 1)
-        else
-            throw(ArgumentError("Invalid symmetry"))
-        end
-    else
-        throw(ArgumentError("Invalid symmetry"))
+    reference = _dense_state_order(Trivial, Trivial; slave_fermion)
+    U = zeros(Int, 3, 3)
+    for (row, state) in enumerate(_dense_state_order(particle_symmetry, spin_symmetry; slave_fermion))
+        U[row, findfirst(==(state), reference)] = 1
     end
+    V = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
+    return TensorMap(U, desymmetrize(V) ← desymmetrize(tj_space(Trivial, Trivial; slave_fermion)))
+end
 
-    return slave_fermion ? transform_slave_fermion(V) : V
+# the states (|0⟩, |↑⟩, |↓⟩) = (1, 2, 3) in the dense order of
+# `tj_space(particle_symmetry, spin_symmetry; slave_fermion)`
+function _dense_state_order(
+        particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
+        slave_fermion::Bool = false
+    )
+    V = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
+    states = Int[]
+    for c in sectors(V)
+        # a one-dimensional auxiliary space maps `c → c ⊠ aux` while preserving the
+        # multiplicity order, so fusing in the auxiliary charge again (it is self-inverse)
+        # recovers the plain-basis sector that identifies the states
+        c′ = slave_fermion ? only(c ⊗ slave_fermion_auxiliary_charge(typeof(c))) : c
+        append!(states, _state_indices(c′, particle_symmetry, spin_symmetry))
+    end
+    return states
+end
+
+# t-J basis indices (|0⟩, |↑⟩, |↓⟩) = (1, 2, 3) contained in sector `c`, in dense row order
+function _state_indices(c, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
+    parity = c isa FermionParity ? c : c[1]
+    return if !parity.isodd # parity even: |0⟩
+        (1,)
+    elseif spin_symmetry === Trivial || spin_symmetry === SU2Irrep
+        (2, 3)
+    else # U1Irrep: Sᶻ distinguishes the states (spin is the last sector factor)
+        spin_sector = particle_symmetry === Trivial ? c[2] : c[3]
+        spin_sector.charge > 0 ? (2,) : (3,)
+    end
+end
+
+# Symmetrize a t-J operator through its basis transformation, in the requested basis. Note
+# that `slave_fermion` is forwarded from the reference operator, which is already expressed
+# in that basis (see `_maybe_slave_fermion`), such that only a permutation remains here.
+function _symmetrize_operator(
+        O::AbstractTensorMap, particle_symmetry::Type{<:Sector},
+        spin_symmetry::Type{<:Sector}; kwargs...
+    )
+    return symmetrize(
+        O, basis_transform(particle_symmetry, spin_symmetry; kwargs...),
+        tj_space(particle_symmetry, spin_symmetry; kwargs...)
+    )
 end
 
 """
     tj_projector(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 
-Projection operator from Hubbard space to t-J space.
-The scalartype is `Int` to avoid floating point errors.
+Projection operator from Hubbard space to t-J space, which removes the doubly occupied state
+``|↑↓⟩``. The t-J operators of this module are related to their
+[`HubbardOperators`](@ref TensorKitTensors.HubbardOperators) counterparts by
+
+```julia
+proj = reduce(⊗, ntuple(Returns(tj_projector(P, S)), N))
+TJOperators.op(elt, P, S) ≈ proj * HubbardOperators.op(elt, P, S) * proj'
+```
+
+for an `N`-site operator `op`. The scalartype is `Int` to avoid floating point errors.
 """
 function tj_projector(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
     Vhub = HubbardOperators.hubbard_space(particle_symmetry, spin_symmetry)
     VtJ = tj_space(particle_symmetry, spin_symmetry)
     proj = zeros(Int, Vhub → VtJ)
 
+    # the retained states are the leading rows of every shared sector: for `Trivial` particle
+    # symmetry `|↑↓⟩` is the *second* even state of the Hubbard space, and for `U1Irrep` it
+    # lives in a sector that has no t-J counterpart at all, so no block of `proj` contains it
     for (f1, f2) in fusiontrees(proj)
         proj[f1, f2][diagind(proj[f1, f2])] .= 1
     end
     return proj
 end
 
-for (opname, alias) in zip(
-        (
-            :e_num, :u_num, :d_num, :h_num,
-            :S_x, :S_y, :S_z, :S_plus, :S_min,
-            :u_plus_u_min, :d_plus_d_min, :u_min_u_plus, :d_min_d_plus,
-            :u_min_d_min, :d_min_u_min, :u_plus_d_plus, :d_plus_u_plus,
-            :u_min_u_min, :d_min_d_min, :u_plus_u_plus, :d_plus_d_plus,
-            :e_plus_e_min, :e_min_e_plus, :e_hopping,
-            :singlet_plus, :singlet_min,
-            :singlet_plus_singlet_min_3site, :singlet_plus_singlet_min_4site,
-            :S_plus_S_min, :S_min_S_plus, :S_exchange,
-        ), (
-            :n, :nꜛ, :nꜜ, :nʰ,
-            :Sˣ, :Sʸ, :Sᶻ, :S⁺, :S⁻,
-            :u⁺u⁻, :d⁺d⁻, :u⁻u⁺, :d⁻d⁺,
-            :u⁻d⁻, :d⁻u⁻, :u⁺d⁺, :d⁺u⁺,
-            :u⁻u⁻, :u⁺u⁺, :d⁻d⁻, :d⁺d⁺,
-            :e⁺e⁻, :e⁻e⁺, :e_hop,
-            :singlet⁺, :singlet⁻,
-            :Δ⁺ij_Δjk, :Δ⁺ij_Δkl,
-            :S⁻S⁺, :S⁺S⁻, :SS,
-        )
-    )
-    # copy over the docstrings
-    @eval begin
-        hub_doc = (@doc HubbardOperators.$opname)
-        tJ_doc = if hub_doc isa Base.Docs.DocStr
-            hub_doc.text[1]
-        else
-            # compatibility with Julia 1.10 (hub_doc is a Markdown.MD object)
-            string(hub_doc)
-        end
-        tJ_doc = if occursin("spin_symmetry::Type{<:Sector}])", tJ_doc)
-            replace(tJ_doc, "spin_symmetry::Type{<:Sector}])" => "spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)")
-        else
-            replace(tJ_doc, "spin_symmetry::Type{<:Sector})" => "spin_symmetry::Type{<:Sector}; slave_fermion::Bool = false)")
-        end
-        tJ_doc = tJ_doc * "Use `slave_fermion = true` to switch to the slave-fermion basis.\n"
-        @doc (tJ_doc) $opname
-    end
-
-    # default arguments
-    @eval $opname(; slave_fermion::Bool = false) =
-        $opname(ComplexF64, Trivial, Trivial; slave_fermion)
-    @eval $opname(
-        particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
-        slave_fermion::Bool = false
-    ) = $opname(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
-    @eval $opname(elt::Type{<:Number}; slave_fermion::Bool = false) =
-        $opname(elt, Trivial, Trivial; slave_fermion)
-
-    # apply projector on Hubbard operator
-    @eval function $opname(
-            elt::Type{<:Number}, particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector};
-            slave_fermion::Bool = false
-        )
-        particle_symmetry == SU2Irrep &&
-            throw(ArgumentError("t-J model does not have ``SU(2)`` particle symmetry."))
-        op_H = HubbardOperators.$opname(elt, particle_symmetry, spin_symmetry)
-        proj = tj_projector(particle_symmetry, spin_symmetry)
-        N = numin(op_H)
-        (N > 1) && (proj = reduce(⊗, ntuple(Returns(proj), N)))
-        op = proj * op_H * proj'
-        return slave_fermion ? transform_slave_fermion(op) : op
-    end
-
-    # define alias
-    isnothing(alias) || @eval begin
-        const $alias = $opname
-    end
-end
-
+# Slave-fermion basis
+# -------------------
 slave_fermion_auxiliary_charge(::Type{FermionParity}) = FermionParity(1)
 slave_fermion_auxiliary_charge(::Type{ProductSector{T}}) where {T} =
     mapreduce(⊠, fieldtypes(T)) do I
@@ -192,6 +232,12 @@ Transform the given operator to the slave-fermion basis, which is related to the
 $_docs_basis_table
 
 where ``h`` is the fermionic holon operator, and ``bꜛ``, ``bꜜ`` are bosonic spinon operators.
+
+Fusing in the auxiliary fermionic charge flips the parity of every state, which changes the
+statistics of the operator: braiding the auxiliary legs of an ``N``-site operator through the
+physical ones generates a staggered sign ``(-1)^{(k-1)p_k}`` on site ``k``, with ``p_k`` the
+parity of the state. Consequently this transformation has to be applied to a complete
+operator, and does not commute with taking tensor products of single-site operators.
 """ transform_slave_fermion
 function transform_slave_fermion(O::AbstractTensorMap)
     (N = numin(O)) == numout(O) || throw(ArgumentError("not a valid operator"))
@@ -205,6 +251,543 @@ function transform_slave_fermion(V::ElementarySpace)
     charge = slave_fermion_auxiliary_charge(sectortype(V))
     V_aux = spacetype(V)(charge => 1)
     return fuse(V, V_aux)
+end
+
+# Express a reference operator in the requested basis. Reference operators are always built up
+# from single-site and multi-site operators in the plain t-J basis, and transformed only once,
+# at the very end: the slave-fermion transformation does not distribute over `⊗`.
+_maybe_slave_fermion(O::AbstractTensorMap, slave_fermion::Bool) =
+    slave_fermion ? transform_slave_fermion(O) : O
+
+function n_site_operator(::Val{N}, elt::Type{<:Number}) where {N}
+    V = tj_space(Trivial, Trivial)
+    return zeros(elt, V^N ← V^N)
+end
+
+# Single-site operators
+# ---------------------
+"""
+    u_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    nꜛ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the one-body operator that counts the number of spin-up electrons.
+"""
+@operator nꜛ function u_num(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(1), elt)
+    I = sectortype(t)
+    t[(I(1), I(1))][1, 1] = 1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    d_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    nꜜ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the one-body operator that counts the number of spin-down electrons.
+"""
+@operator nꜜ function d_num(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(1), elt)
+    I = sectortype(t)
+    t[(I(1), I(1))][2, 2] = 1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    e_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    n([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the one-body operator that counts the number of electrons.
+"""
+@operator n function e_num(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = u_num(elt, Trivial, Trivial) + d_num(elt, Trivial, Trivial)
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    h_num([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    nʰ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the one-body operator that counts the number of holes, i.e. the number of
+non-occupied sites.
+"""
+@operator nʰ function h_num(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = id(elt, tj_space(Trivial, Trivial)) - e_num(elt, Trivial, Trivial)
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the spin-plus operator `S⁺ = e†_↑ e_↓` (only compatible with `Trivial` spin symmetry).
+"""
+@operator S⁺ function S_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(1), elt)
+    I = sectortype(t)
+    t[(I(1), I(1))][1, 2] = 1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the spin-minus operator `S⁻ = e†_↓ e_↑` (only compatible with `Trivial` spin symmetry).
+"""
+@operator S⁻ function S_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = copy(adjoint(S_plus(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    S_x([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    Sˣ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the one-body spin-1/2 x-operator on the electrons (only compatible with `Trivial` spin symmetry).
+"""
+@operator Sˣ function S_x(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = (S_plus(elt, Trivial, Trivial) + S_min(elt, Trivial, Trivial)) / 2
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    S_y([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    Sʸ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the one-body spin-1/2 y-operator on the electrons (only compatible with `Trivial` spin symmetry).
+"""
+@operator Sʸ function S_y(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    # explicit error to avoid infinite recursion:
+    elt <: Real && throw(ArgumentError("S_y requires `elt <: Complex`"))
+    t = (S_plus(elt, Trivial, Trivial) - S_min(elt, Trivial, Trivial)) / (2im)
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    S_z([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    Sᶻ([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the one-body spin-1/2 z-operator on the electrons.
+"""
+@operator Sᶻ function S_z(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = (u_num(elt, Trivial, Trivial) - d_num(elt, Trivial, Trivial)) / 2
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+# Two site operators
+# ------------------
+"""
+    u_plus_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    u⁺u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↑} e_{2,↑}`` that creates a spin-up electron at the
+first site and annihilates a spin-up electron at the second. The only nonzero matrix element is
+```
+    +|↑,0⟩ ↤ |0,↑⟩
+```
+"""
+@operator u⁺u⁻ function u_plus_u_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(2), elt)
+    I = sectortype(t)
+    t[(I(1), I(0), dual(I(0)), dual(I(1)))][1, 1, 1, 1] = 1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    d_plus_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    d⁺d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↓} e_{2,↓}`` that creates a spin-down electron at the
+first site and annihilates a spin-down electron at the second. The only nonzero matrix element is
+```
+    +|↓,0⟩ ↤ |0,↓⟩
+```
+"""
+@operator d⁺d⁻ function d_plus_d_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(2), elt)
+    I = sectortype(t)
+    t[(I(1), I(0), dual(I(0)), dual(I(1)))][2, 1, 1, 2] = 1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    u_min_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    u⁻u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e_{1,↑} e†_{2,↑}`` that annihilates a spin-up electron at the
+first site and creates a spin-up electron at the second.
+"""
+@operator u⁻u⁺ function u_min_u_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = -copy(adjoint(u_plus_u_min(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    d_min_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    d⁻d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e_{1,↓} e†_{2,↓}`` that annihilates a spin-down electron at the
+first site and creates a spin-down electron at the second.
+"""
+@operator d⁻d⁺ function d_min_d_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = -copy(adjoint(d_plus_d_min(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    e_plus_e_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    e⁺e⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator that creates an electron at the first site and annihilates an
+electron at the second. This is the sum of `u_plus_u_min` and `d_plus_d_min`.
+"""
+@operator e⁺e⁻ function e_plus_e_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = u_plus_u_min(elt, Trivial, Trivial) + d_plus_d_min(elt, Trivial, Trivial)
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    e_min_e_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    e⁻e⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator that annihilates an electron at the first site and creates an
+electron at the second. This is the sum of `u_min_u_plus` and `d_min_d_plus`.
+"""
+@operator e⁻e⁺ function e_min_e_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = -copy(adjoint(e_plus_e_min(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    e_hopping([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    e_hop([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator that describes an electron that hops between the first and the
+second site.
+"""
+@operator e_hop function e_hopping(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = e_plus_e_min(elt, Trivial, Trivial) - e_min_e_plus(elt, Trivial, Trivial)
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    u_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    u⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up electron at the
+first site and a spin-down electron at the second site. The only nonzero matrix element is
+```
+    -|0,0⟩ ↤ |↑,↓⟩
+```
+This operator does not conserve the number of electrons, and is therefore only compatible
+with `Trivial` particle symmetry.
+"""
+@operator u⁻d⁻ function u_min_d_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(2), elt)
+    I = sectortype(t)
+    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 2] = -1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    u_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    u⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that creates a spin-up electron at the
+first site and a spin-down electron at the second site.
+"""
+@operator u⁺d⁺ function u_plus_d_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = -copy(adjoint(u_min_d_min(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    d_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    d⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down electron at the
+first site and a spin-up electron at the second site. The only nonzero matrix element is
+```
+    -|0,0⟩ ↤ |↓,↑⟩
+```
+This operator does not conserve the number of electrons, and is therefore only compatible
+with `Trivial` particle symmetry.
+"""
+@operator d⁻u⁻ function d_min_u_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(2), elt)
+    I = sectortype(t)
+    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 1] = -1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    d_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    d⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down electron at the
+first site and a spin-up electron at the second site.
+"""
+@operator d⁺u⁺ function d_plus_u_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = -copy(adjoint(d_min_u_min(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    u_min_u_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    u⁻u⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e_{1,↑} e_{2,↑}`` that annihilates a spin-up electron at both
+sites. The only nonzero matrix element is
+```
+    -|0,0⟩ ↤ |↑,↑⟩
+```
+This operator conserves neither the number of electrons nor ``S^z``, and is therefore only
+compatible with `Trivial` particle and spin symmetry.
+"""
+@operator u⁻u⁻ function u_min_u_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(2), elt)
+    I = sectortype(t)
+    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 1, 1] = -1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    u_plus_u_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    u⁺u⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up electron at both sites.
+"""
+@operator u⁺u⁺ function u_plus_u_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = -copy(adjoint(u_min_u_min(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    d_min_d_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    d⁻d⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e_{1,↓} e_{2,↓}`` that annihilates a spin-down electron at both
+sites. The only nonzero matrix element is
+```
+    -|0,0⟩ ↤ |↓,↓⟩
+```
+This operator conserves neither the number of electrons nor ``S^z``, and is therefore only
+compatible with `Trivial` particle and spin symmetry.
+"""
+@operator d⁻d⁻ function d_min_d_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(2), elt)
+    I = sectortype(t)
+    t[(I(0), I(0), dual(I(1)), dual(I(1)))][1, 1, 2, 2] = -1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    d_plus_d_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    d⁺d⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down electron at both sites.
+"""
+@operator d⁺d⁺ function d_plus_d_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = -copy(adjoint(d_min_d_min(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    singlet_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    singlet⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``,
+which creates the singlet state when acting on vacuum.
+"""
+@operator singlet⁺ function singlet_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = (u_plus_d_plus(elt, Trivial, Trivial) - d_plus_u_plus(elt, Trivial, Trivial)) /
+        sqrt(2)
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    singlet_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    singlet⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the adjoint of `singlet_plus` operator, which is
+``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / \\sqrt{2}``.
+"""
+@operator singlet⁻ function singlet_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = copy(adjoint(singlet_plus(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    singlet_plus_singlet_min_3site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    Δ⁺ij_Δjk([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Returns the 3-site term ``O_{ijk} = Δ^†_{ij} Δ_{jk}``, where
+``Δ^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
+It describes the hopping of a singlet pair from bond `(j,k)`
+to a nearest neighbor bond `(i,j)` sharing site `j`.
+"""
+@operator Δ⁺ij_Δjk function singlet_plus_singlet_min_3site(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    #=
+                -5      -6
+            ┌---┴-------┴---┐
+            |     A_{jk}    |
+            └---┬-------┬---┘
+        -4      1       -3
+    ┌---┴-------┴---┐
+    |    A†_{ij}    |
+    └---┬-------┬---┘
+        -1      -2
+        i       j       k
+    =#
+    singp = singlet_plus(elt, Trivial, Trivial)
+    singm = singp'
+    @tensor t[-1 -2 -3; -4 -5 -6] := singp[-1 -2; -4 1] * singm[1 -3; -5 -6]
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    singlet_plus_singlet_min_4site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    Δ⁺ij_Δkl([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Returns the 4-site term ``O_{ijkl} = Δ^†_{ij} Δ_{kl}``, where
+``Δ^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
+It measures the singlet pair correlation between two bonds `(i,j)` and `(k,l)`.
+"""
+@operator Δ⁺ij_Δkl function singlet_plus_singlet_min_4site(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    singp = singlet_plus(elt, Trivial, Trivial)
+    return _maybe_slave_fermion(singp ⊗ singp', slave_fermion)
+end
+
+"""
+    S_plus_S_min([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    S⁺S⁻([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator S⁺S⁻.
+The only nonzero matrix element corresponds to `|↑,↓⟩ <-- |↓,↑⟩`.
+"""
+@operator S⁺S⁻ function S_plus_S_min(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = n_site_operator(Val(2), elt)
+    I = sectortype(t)
+    t[(I(1), I(1), dual(I(1)), dual(I(1)))][1, 2, 2, 1] = 1
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    S_min_S_plus([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    S⁻S⁺([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the two-body operator S⁻S⁺.
+The only nonzero matrix element corresponds to `|↓,↑⟩ <-- |↑,↓⟩`.
+"""
+@operator S⁻S⁺ function S_min_S_plus(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    t = copy(adjoint(S_plus_S_min(elt, Trivial, Trivial)))
+    return _maybe_slave_fermion(t, slave_fermion)
+end
+
+"""
+    S_exchange([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+    SS([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
+
+Return the spin exchange operator S⋅S.
+"""
+@operator SS function S_exchange(
+        elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
+        slave_fermion::Bool = false
+    )
+    Sz = S_z(elt, Trivial, Trivial)
+    t = Sz ⊗ Sz +
+        (S_plus_S_min(elt, Trivial, Trivial) + S_min_S_plus(elt, Trivial, Trivial)) / 2
+    return _maybe_slave_fermion(t, slave_fermion)
 end
 
 end

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -191,8 +191,8 @@ end
     tj_projector(particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector})
 
 Projection operator from Hubbard space to t-J space, which removes the doubly occupied state
-``|↑↓⟩``. The t-J operators of this module are related to their
-[`HubbardOperators`](@ref TensorKitTensors.HubbardOperators) counterparts by
+``|↑↓⟩``. The t-J operators of this module are related to their `HubbardOperators`
+counterparts by
 
 ```julia
 proj = reduce(⊗, ntuple(Returns(tj_projector(P, S)), N))

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -259,236 +259,103 @@ _maybe_slave_fermion(O::AbstractTensorMap, slave_fermion::Bool) =
 # ---------
 # The operators of this module are the projections of the `HubbardOperators` operators of the
 # same name, so both the definitions and their docstrings are generated from a single registry
-# of `(name, alias, description)` entries. Keeping the name and its alias in a single entry is
-# deliberate: zipping two separate lists silently misaligned three aliases in the past.
+# of `(name, alias)` entries, and the description of an operator is inherited from the docstring
+# of its Hubbard counterpart, which is the single source of truth. Keeping the name and its
+# alias in a single entry is deliberate: zipping two separate lists silently misaligned three
+# aliases in the past.
 
 const _OPERATOR_ARGS = "([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)"
 
-# signature block for both names, the operator-specific description, and the boilerplate that
-# relates the operator to its Hubbard counterpart and to the slave-fermion basis
-function _operator_docstring(name::Symbol, alias::Symbol, description::AbstractString)
+# signature block for both names, the description inherited from the Hubbard counterpart, and
+# the boilerplate that relates the operator to that counterpart and to the slave-fermion basis
+function _operator_docstring(name::Symbol, alias::Symbol, hubbard_doc)
     return string(
         "    ", name, _OPERATOR_ARGS, "\n",
         "    ", alias, _OPERATOR_ARGS, "\n\n",
-        strip(description), "\n\n",
-        "This operator is the projection of `HubbardOperators.", name, "` onto the t-J space, ",
-        "see [`tj_projector`](@ref). Use `slave_fermion = true` to obtain it in the ",
-        "slave-fermion basis, see [`transform_slave_fermion`](@ref).\n",
+        _inherit_description(_docstring_text(hubbard_doc)), "\n\n",
+        "This operator is the projection of [`HubbardOperators.", name,
+        "`](@ref HubbardOperators.", name, ") onto the t-J space, see [`tj_projector`](@ref). ",
+        "Use `slave_fermion = true` to obtain it in the slave-fermion basis, see ",
+        "[`transform_slave_fermion`](@ref).\n",
     )
+end
+
+# `@doc` hands back the raw `DocStr` on recent Julia versions, and a rendered `Markdown.MD`
+# object on older ones; stringifying the latter reflows the text and writes inline math as
+# `$x$` instead of ``x``, which parses the same way.
+_docstring_text(doc::Base.Docs.DocStr) = join(doc.text)
+_docstring_text(doc) = string(doc)
+
+# Keep the prose of a Hubbard docstring, dropping the signature block -- which is regenerated
+# above, with the `slave_fermion` keyword -- as well as any admonition, which by convention
+# holds Hubbard-specific detail that does not carry over to the projected operator. The
+# signature block is indented in the raw docstring, and a fenced code block in the rendered one.
+_is_toplevel(line) = !isempty(strip(line)) && !startswith(line, ' ')
+function _inherit_description(docstring::AbstractString)
+    lines = split(docstring, '\n')
+    i = if startswith(first(lines), "```")
+        closing = findnext(startswith("```"), lines, firstindex(lines) + 1)
+        something(closing, lastindex(lines)) + 1
+    else
+        something(findfirst(_is_toplevel, lines), lastindex(lines) + 1)
+    end
+    description = String[]
+    while i <= lastindex(lines)
+        if startswith(lines[i], "!!! ")
+            i += 1
+            while i <= lastindex(lines) && !_is_toplevel(lines[i])
+                i += 1
+            end
+        else
+            push!(description, lines[i])
+            i += 1
+        end
+    end
+    return strip(join(description, '\n'))
 end
 
 const _OPERATORS = (
     # single-site operators
-    (
-        :u_num, :nꜛ, """
-        Return the one-body operator that counts the number of spin-up electrons.
-        """,
-    ),
-    (
-        :d_num, :nꜜ, """
-        Return the one-body operator that counts the number of spin-down electrons.
-        """,
-    ),
-    (
-        :e_num, :n, """
-        Return the one-body operator that counts the number of electrons.
-        """,
-    ),
-    (
-        :h_num, :nʰ, """
-        Return the one-body operator that counts the number of holes, i.e. the number of non-occupied sites.
-        """,
-    ),
-    (
-        :S_plus, :S⁺, """
-        Return the spin-plus operator `S⁺ = e†_↑ e_↓` (only compatible with `Trivial` spin symmetry).
-        """,
-    ),
-    (
-        :S_min, :S⁻, """
-        Return the spin-minus operator `S⁻ = e†_↓ e_↑` (only compatible with `Trivial` spin symmetry).
-        """,
-    ),
-    (
-        :S_x, :Sˣ, """
-        Return the one-body spin-1/2 x-operator on the electrons (only compatible with `Trivial` spin symmetry).
-        """,
-    ),
-    (
-        :S_y, :Sʸ, """
-        Return the one-body spin-1/2 y-operator on the electrons (only compatible with `Trivial` spin symmetry).
-        This operator requires a complex scalar type.
-        """,
-    ),
-    (
-        :S_z, :Sᶻ, """
-        Return the one-body spin-1/2 z-operator on the electrons.
-        """,
-    ),
+    (:u_num, :nꜛ),
+    (:d_num, :nꜜ),
+    (:e_num, :n),
+    (:h_num, :nʰ),
+    (:S_plus, :S⁺),
+    (:S_min, :S⁻),
+    (:S_x, :Sˣ),
+    (:S_y, :Sʸ),
+    (:S_z, :Sᶻ),
     # two-site operators
-    (
-        :u_plus_u_min, :u⁺u⁻, """
-        Return the two-body operator ``e†_{1,↑} e_{2,↑}`` that creates a spin-up electron at the first site and annihilates a spin-up electron at the second.
-        The only nonzero matrix element is
-        ```
-            +|↑,0⟩ ↤ |0,↑⟩
-        ```
-        """,
-    ),
-    (
-        :d_plus_d_min, :d⁺d⁻, """
-        Return the two-body operator ``e†_{1,↓} e_{2,↓}`` that creates a spin-down electron at the first site and annihilates a spin-down electron at the second.
-        The only nonzero matrix element is
-        ```
-            +|↓,0⟩ ↤ |0,↓⟩
-        ```
-        """,
-    ),
-    (
-        :u_min_u_plus, :u⁻u⁺, """
-        Return the two-body operator ``e_{1,↑} e†_{2,↑}`` that annihilates a spin-up electron at the first site and creates a spin-up electron at the second.
-        """,
-    ),
-    (
-        :d_min_d_plus, :d⁻d⁺, """
-        Return the two-body operator ``e_{1,↓} e†_{2,↓}`` that annihilates a spin-down electron at the first site and creates a spin-down electron at the second.
-        """,
-    ),
-    (
-        :e_plus_e_min, :e⁺e⁻, """
-        Return the two-body operator that creates an electron at the first site and annihilates an electron at the second.
-        This is the sum of `u_plus_u_min` and `d_plus_d_min`.
-        """,
-    ),
-    (
-        :e_min_e_plus, :e⁻e⁺, """
-        Return the two-body operator that annihilates an electron at the first site and creates an electron at the second.
-        This is the sum of `u_min_u_plus` and `d_min_d_plus`.
-        """,
-    ),
-    (
-        :e_hopping, :e_hop, """
-        Return the two-body operator that describes an electron that hops between the first and the second site.
-        """,
-    ),
-    (
-        :u_min_d_min, :u⁻d⁻, """
-        Return the two-body operator ``e_{1,↑} e_{2,↓}`` that annihilates a spin-up electron at the first site and a spin-down electron at the second site.
-        The only nonzero matrix element is
-        ```
-            -|0,0⟩ ↤ |↑,↓⟩
-        ```
-        This operator does not conserve the number of electrons, and is therefore only compatible with `Trivial` particle symmetry.
-        """,
-    ),
-    (
-        :u_plus_d_plus, :u⁺d⁺, """
-        Return the two-body operator ``e†_{1,↑} e†_{2,↓}`` that creates a spin-up electron at the first site and a spin-down electron at the second site.
-        """,
-    ),
-    (
-        :d_min_u_min, :d⁻u⁻, """
-        Return the two-body operator ``e_{1,↓} e_{2,↑}`` that annihilates a spin-down electron at the first site and a spin-up electron at the second site.
-        The only nonzero matrix element is
-        ```
-            -|0,0⟩ ↤ |↓,↑⟩
-        ```
-        This operator does not conserve the number of electrons, and is therefore only compatible with `Trivial` particle symmetry.
-        """,
-    ),
-    (
-        :d_plus_u_plus, :d⁺u⁺, """
-        Return the two-body operator ``e†_{1,↓} e†_{2,↑}`` that creates a spin-down electron at the first site and a spin-up electron at the second site.
-        """,
-    ),
-    (
-        :u_min_u_min, :u⁻u⁻, """
-        Return the two-body operator ``e_{1,↑} e_{2,↑}`` that annihilates a spin-up electron at both sites.
-        The only nonzero matrix element is
-        ```
-            -|0,0⟩ ↤ |↑,↑⟩
-        ```
-        This operator conserves neither the number of electrons nor ``S^z``, and is therefore only compatible with `Trivial` particle and spin symmetry.
-        """,
-    ),
-    (
-        :u_plus_u_plus, :u⁺u⁺, """
-        Return the two-body operator ``e†_{1,↑} e†_{2,↑}`` that creates a spin-up electron at both sites.
-        """,
-    ),
-    (
-        :d_min_d_min, :d⁻d⁻, """
-        Return the two-body operator ``e_{1,↓} e_{2,↓}`` that annihilates a spin-down electron at both
-        sites. The only nonzero matrix element is
-        ```
-            -|0,0⟩ ↤ |↓,↓⟩
-        ```
-        This operator conserves neither the number of electrons nor ``S^z``, and is therefore only
-        compatible with `Trivial` particle and spin symmetry.
-        """,
-    ),
-    (
-        :d_plus_d_plus, :d⁺d⁺, """
-        Return the two-body operator ``e†_{1,↓} e†_{2,↓}`` that creates a spin-down electron at both sites.
-        """,
-    ),
-    (
-        :singlet_plus, :singlet⁺, """
-        Return the two-body singlet operator ``(e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``, which creates the singlet state when acting on vacuum.
-        """,
-    ),
-    (
-        :singlet_min, :singlet⁻, """
-        Return the adjoint of `singlet_plus` operator, which is ``(-e_{1,↑} e_{2,↓} + e_{1,↓} e_{2,↑}) / \\sqrt{2}``.
-        """,
-    ),
-    (
-        :singlet_plus_singlet_min_3site, :Δ⁺ij_Δjk, """
-        Returns the 3-site term ``O_{ijk} = Δ^†_{ij} Δ_{jk}``, where ``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
-        It describes the hopping of a singlet pair from bond `(j,k)` to a nearest neighbor bond `(i,j)` sharing site `j`.
-        The indices are ordered as
-        ```
-                    -5      -6
-                ┌---┴-------┴---┐
-                |     Δ_{jk}    |
-                └---┬-------┬---┘
-            -4      1       -3
-        ┌---┴-------┴---┐
-        |    Δ†_{ij}    |
-        └---┬-------┬---┘
-            -1      -2
-            i       j       k
-        ```
-        """,
-    ),
-    (
-        :singlet_plus_singlet_min_4site, :Δ⁺ij_Δkl, """
-        Returns the 4-site term ``O_{ijkl} = Δ^†_{ij} Δ_{kl}``, where ``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
-        It measures the singlet pair correlation between two bonds `(i,j)` and `(k,l)`.
-        """,
-    ),
-    (
-        :S_plus_S_min, :S⁺S⁻, """
-        Return the two-body operator S⁺S⁻.
-        The only nonzero matrix element corresponds to `|↑,↓⟩ <-- |↓,↑⟩`.
-        """,
-    ),
-    (
-        :S_min_S_plus, :S⁻S⁺, """
-        Return the two-body operator S⁻S⁺.
-        The only nonzero matrix element corresponds to `|↓,↑⟩ <-- |↑,↓⟩`.
-        """,
-    ),
-    (
-        :S_exchange, :SS, """
-        Return the spin exchange operator S⋅S.
-        """,
-    ),
+    (:u_plus_u_min, :u⁺u⁻),
+    (:d_plus_d_min, :d⁺d⁻),
+    (:u_min_u_plus, :u⁻u⁺),
+    (:d_min_d_plus, :d⁻d⁺),
+    (:e_plus_e_min, :e⁺e⁻),
+    (:e_min_e_plus, :e⁻e⁺),
+    (:e_hopping, :e_hop),
+    (:u_min_d_min, :u⁻d⁻),
+    (:u_plus_d_plus, :u⁺d⁺),
+    (:d_min_u_min, :d⁻u⁻),
+    (:d_plus_u_plus, :d⁺u⁺),
+    (:u_min_u_min, :u⁻u⁻),
+    (:u_plus_u_plus, :u⁺u⁺),
+    (:d_min_d_min, :d⁻d⁻),
+    (:d_plus_d_plus, :d⁺d⁺),
+    (:singlet_plus, :singlet⁺),
+    (:singlet_min, :singlet⁻),
+    (:singlet_plus_singlet_min_3site, :Δ⁺ij_Δjk),
+    (:singlet_plus_singlet_min_4site, :Δ⁺ij_Δkl),
+    (:S_plus_S_min, :S⁺S⁻),
+    (:S_min_S_plus, :S⁻S⁺),
+    (:S_exchange, :SS),
 )
 
-for (name, alias, description) in _OPERATORS
+for (name, alias) in _OPERATORS
+    # the parentheses are required: a bare `@doc x` at the end of a line makes the parser
+    # attach the next expression as the one being documented
+    hubbard_doc = @eval @doc(HubbardOperators.$name)
     @eval export $name, $alias
-    @eval @doc $(_operator_docstring(name, alias, description)) @operator $alias function $name(
+    @eval @doc $(_operator_docstring(name, alias, hubbard_doc)) @operator $alias function $name(
             elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
             slave_fermion::Bool = false
         )

--- a/src/tjoperators.jl
+++ b/src/tjoperators.jl
@@ -699,10 +699,8 @@ end
     singlet_plus_singlet_min_3site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
     Δ⁺ij_Δjk([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
 
-Returns the 3-site term ``O_{ijk} = Δ^†_{ij} Δ_{jk}``, where
-``Δ^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
-It describes the hopping of a singlet pair from bond `(j,k)`
-to a nearest neighbor bond `(i,j)` sharing site `j`.
+Returns the 3-site term ``O_{ijk} = Δ^†_{ij} Δ_{jk}``, where ``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
+It describes the hopping of a singlet pair from bond `(j,k)` to a nearest neighbor bond `(i,j)` sharing site `j`.
 """
 @operator Δ⁺ij_Δjk function singlet_plus_singlet_min_3site(
         elt::Type{<:Number}, ::Type{Trivial}, ::Type{Trivial};
@@ -730,8 +728,7 @@ end
     singlet_plus_singlet_min_4site([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
     Δ⁺ij_Δkl([elt::Type{<:Number}], [particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}]; slave_fermion::Bool = false)
 
-Returns the 4-site term ``O_{ijkl} = Δ^†_{ij} Δ_{kl}``, where
-``Δ^†_{ij} = (e^†_{1,↑} e^†_{2,↓} - e^†_{1,↓} e^†_{2,↑}) / \\sqrt{2}``.
+Returns the 4-site term ``O_{ijkl} = Δ^†_{ij} Δ_{kl}``, where ``Δ^†_{ij} = (e^†_{i,↑} e^†_{j,↓} - e^†_{i,↓} e^†_{j,↑}) / \\sqrt{2}``.
 It measures the singlet pair correlation between two bonds `(i,j)` and `(k,l)`.
 """
 @operator Δ⁺ij_Δkl function singlet_plus_singlet_min_4site(

--- a/test/hubbardoperators.jl
+++ b/test/hubbardoperators.jl
@@ -267,36 +267,6 @@ function hubbard_hamiltonian(particle_symmetry, spin_symmetry; t, U, mu)
 
     return H
 end
-# particle-hole symmetric Hamiltonian (mu = U/2), compatible with all symmetries
-function hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
-    @assert length(t) + 1 == length(U)
-    hopping = e_hopping(particle_symmetry, spin_symmetry)
-    interaction = half_ud_num(particle_symmetry, spin_symmetry)
-    H = operator_sum(hopping, -t) +
-        operator_sum(interaction, U)
-    return H
-end
-
-@testset "spectrum" begin
-    rng = StableRNG(123)
-    L = 4
-    t = randn(rng, L - 1)
-    U = randn(rng, L)
-
-    # particle-hole symmetric spectrum across all symmetry combinations: a many-body
-    # integration check that the staggered η-gauge e_hopping (verified element-wise per-bond
-    # above) assembles correctly into a chain under SU2 particle symmetry.
-    H_triv = hubbard_hamiltonian_ph(Trivial, Trivial; t, U)
-    vals_triv = expanded_eigenvalues(H_triv)
-
-    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
-        particle_symmetry == spin_symmetry == Trivial && continue
-        H_symm = hubbard_hamiltonian_ph(particle_symmetry, spin_symmetry; t, U)
-        vals_symm = expanded_eigenvalues(H_symm)
-        @test vals_triv ≈ vals_symm
-    end
-end
-
 @testset "Exact diagonalisation" begin
     for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
         has_e_num(particle_symmetry, spin_symmetry) || continue

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -171,28 +171,6 @@ end
         Set((:hubbard_space, :ud_num, :nꜛꜜ, :half_ud_num))
 end
 
-@testset "docstrings" begin
-    # the descriptions are inherited from the `HubbardOperators` docstrings, which relies on
-    # what `@doc` returns: the raw docstring on recent Julia versions, and a rendered
-    # `Markdown.MD` object on older ones
-    for (name, alias) in TJOperators._OPERATORS
-        doc = TJOperators._operator_docstring(name, alias, @eval @doc(HO.$name))
-        @test occursin("    $name(", doc)
-        @test occursin("    $alias(", doc)
-        @test !occursin("!!!", doc)  # Hubbard-specific admonitions are not inherited
-
-        # the inherited description sits between the signature block and the boilerplate
-        description = strip(split(doc, "\n\n")[2])
-        @test !isempty(description)
-        @test !startswith(description, "```") && !startswith(description, " ")
-
-        # and the composed docstring ends up attached to the operator itself
-        registered = TJOperators._docstring_text(@eval @doc(TJOperators.$name))
-        @test occursin("slave_fermion", registered)
-        @test occursin("tj_projector", registered)
-    end
-end
-
 @testset "regression values" begin
     # regression check: hand-written symmetric operators are easily transposed. The dense
     # indices of the basis states are read off from the basis transform, whose columns are

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -171,6 +171,28 @@ end
         Set((:hubbard_space, :ud_num, :nꜛꜜ, :half_ud_num))
 end
 
+@testset "docstrings" begin
+    # the descriptions are inherited from the `HubbardOperators` docstrings, which relies on
+    # what `@doc` returns: the raw docstring on recent Julia versions, and a rendered
+    # `Markdown.MD` object on older ones
+    for (name, alias) in TJOperators._OPERATORS
+        doc = TJOperators._operator_docstring(name, alias, @eval @doc(HO.$name))
+        @test occursin("    $name(", doc)
+        @test occursin("    $alias(", doc)
+        @test !occursin("!!!", doc)  # Hubbard-specific admonitions are not inherited
+
+        # the inherited description sits between the signature block and the boilerplate
+        description = strip(split(doc, "\n\n")[2])
+        @test !isempty(description)
+        @test !startswith(description, "```") && !startswith(description, " ")
+
+        # and the composed docstring ends up attached to the operator itself
+        registered = TJOperators._docstring_text(@eval @doc(TJOperators.$name))
+        @test occursin("slave_fermion", registered)
+        @test occursin("tj_projector", registered)
+    end
+end
+
 @testset "regression values" begin
     # regression check: hand-written symmetric operators are easily transposed. The dense
     # indices of the basis states are read off from the basis transform, whose columns are

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -11,6 +11,8 @@ using StableRNGs
 particle_syms = (Trivial, U1Irrep)
 spin_syms = (Trivial, U1Irrep, SU2Irrep)
 bases = (false, true)
+symmetries = Iterators.product(particle_syms, spin_syms)
+symmetries_bases = Iterators.product(particle_syms, spin_syms, bases)
 
 # operator availability, as determined by the symmetries each operator breaks:
 # - u_num, d_num, S_z and the u/d hopping and spin-flip pairs break SU2 spin symmetry
@@ -30,7 +32,7 @@ has_triplet(P, S) = P === Trivial && S === Trivial
 const ALWAYS = (e_num, h_num, e_plus_e_min, e_min_e_plus, e_hopping, S_exchange, Δ⁺ij_Δjk, Δ⁺ij_Δkl)
 
 @testset "basis transformations" begin
-    for (P, S, slave_fermion) in Iterators.product(particle_syms, spin_syms, bases)
+    for (P, S, slave_fermion) in symmetries_bases
         U = basis_transform(P, S; slave_fermion)
         @test U isa AbstractTensorMap{Int}
         @test U' * U == one(U)
@@ -75,8 +77,7 @@ end
 end
 
 @testset "Compare symmetric with trivial tensors" begin
-    for (particle_symmetry, spin_symmetry, slave_fermion) in
-            Iterators.product(particle_syms, spin_syms, bases)
+    for (particle_symmetry, spin_symmetry, slave_fermion) in symmetries_bases
         space = @testinferred tj_space(particle_symmetry, spin_symmetry; slave_fermion)
         @test dim(space) == 3
 
@@ -111,7 +112,7 @@ end
 @testset "slave-fermion basis" begin
     # the reference operators are transformed to the slave-fermion basis before they are
     # symmetrized, which has to agree with transforming the symmetric operator itself
-    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+    for (particle_symmetry, spin_symmetry) in symmetries
         for f in (
                 ALWAYS..., u_num, d_num, S_z, S_plus_S_min, S_min_S_plus, S_x, S_y, S_plus,
                 S_min, u_min_d_min, d_min_u_min, u_plus_d_plus, d_plus_u_plus, singlet_plus,
@@ -132,7 +133,7 @@ end
 
 @testset "Hubbard projection" begin
     # the relation to the Hubbard operators: project out the doubly occupied state
-    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+    for (particle_symmetry, spin_symmetry) in symmetries
         proj = tj_projector(particle_symmetry, spin_symmetry)
         @test proj isa AbstractTensorMap{Int}
         @test proj * proj' ≈ id(tj_space(particle_symmetry, spin_symmetry))
@@ -160,7 +161,7 @@ end
     # regression check: hand-written symmetric operators are easily transposed. The dense
     # indices of the basis states are read off from the basis transform, whose columns are
     # ordered as (|0⟩, |↑⟩, |↓⟩) in the plain t-J basis.
-    for (P, S) in Iterators.product(particle_syms, spin_syms)
+    for (P, S) in symmetries
         U = convert(Array, basis_transform(P, S))
         i0 = findfirst(==(1), U[:, 1])
         iu = findfirst(==(1), U[:, 2])
@@ -179,8 +180,7 @@ end
 end
 
 @testset "basic properties" begin
-    for (particle_symmetry, spin_symmetry, slave_fermion) in
-            Iterators.product(particle_syms, spin_syms, bases)
+    for (particle_symmetry, spin_symmetry, slave_fermion) in symmetries_bases
         pspace = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
 
         # hopping operators
@@ -305,7 +305,7 @@ end
     rng = StableRNG(123)
     t, J = rand(rng, 2)
     true_eigenvals = sort(vcat(-J, fill(-t, 2), fill(t, 2), fill(0.0, 4)))
-    for (P, S, slave_fermion) in Iterators.product(particle_syms, spin_syms, bases)
+    for (P, S, slave_fermion) in symmetries_bases
         H = tjhamiltonian(P, S; t, J, mu = 0.0, L = 2, slave_fermion)
         eigenvals = expanded_eigenvalues(H)
         @test eigenvals ≈ true_eigenvals

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -301,25 +301,6 @@ function tjhamiltonian(particle_symmetry, spin_symmetry; t, J, mu, L, slave_ferm
     return H
 end
 
-@testset "spectrum" begin
-    rng = StableRNG(123)
-    L = 4
-    for slave_fermion in bases
-        t, J, mu = rand(rng, 3)
-        H_triv = tjhamiltonian(Trivial, Trivial; t, J, mu, L, slave_fermion)
-        vals_triv = expanded_eigenvalues(H_triv)
-
-        for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
-            (particle_symmetry, spin_symmetry) == (Trivial, Trivial) && continue
-            H_symm = tjhamiltonian(
-                particle_symmetry, spin_symmetry; t, J, mu, L, slave_fermion
-            )
-            vals_symm = expanded_eigenvalues(H_symm)
-            @test vals_triv ≈ vals_symm
-        end
-    end
-end
-
 @testset "Exact Diagonalisation" begin
     rng = StableRNG(123)
     t, J = rand(rng, 2)

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -138,9 +138,11 @@ end
         @test proj isa AbstractTensorMap{Int}
         @test proj * proj' ≈ id(tj_space(particle_symmetry, spin_symmetry))
         for name in (
-                :e_num, :h_num, :u_num, :d_num, :S_z, :S_x, :S_plus, :S_min,
-                :u_plus_u_min, :d_plus_d_min, :e_plus_e_min, :e_min_e_plus, :e_hopping,
-                :u_min_d_min, :d_min_u_min, :u_min_u_min, :d_min_d_min,
+                :e_num, :h_num, :u_num, :d_num, :S_z, :S_x, :S_y, :S_plus, :S_min,
+                :u_plus_u_min, :d_plus_d_min, :u_min_u_plus, :d_min_d_plus,
+                :e_plus_e_min, :e_min_e_plus, :e_hopping,
+                :u_min_d_min, :d_min_u_min, :u_plus_d_plus, :d_plus_u_plus,
+                :u_min_u_min, :d_min_d_min, :u_plus_u_plus, :d_plus_d_plus,
                 :singlet_plus, :singlet_min, :S_plus_S_min, :S_min_S_plus, :S_exchange,
                 :singlet_plus_singlet_min_3site, :singlet_plus_singlet_min_4site,
             )
@@ -155,6 +157,18 @@ end
             @test projⁿ * O_hub * projⁿ' ≈ O_tj
         end
     end
+end
+
+@testset "Hubbard operator coverage" begin
+    # every t-J operator is generated from the `HubbardOperators` operator of the same name, so
+    # the exported names may only differ by the spaces, the basis utilities, and the
+    # double-occupancy operators (which project to zero and have no t-J counterpart)
+    tj_names = filter(!=(nameof(TJOperators)), names(TJOperators))
+    hub_names = filter(!=(nameof(HO)), names(HO))
+    @test Set(setdiff(tj_names, hub_names)) ==
+        Set((:tj_space, :tj_projector, :transform_slave_fermion))
+    @test Set(setdiff(hub_names, tj_names)) ==
+        Set((:hubbard_space, :ud_num, :nꜛꜜ, :half_ud_num))
 end
 
 @testset "regression values" begin

--- a/test/tjoperators.jl
+++ b/test/tjoperators.jl
@@ -3,14 +3,69 @@ using LinearAlgebra: eigvals
 using Test
 include("testsetup.jl")
 using .TensorKitTensorsTestSetup
+using TensorKitTensors: desymmetrize
 using TensorKitTensors.TJOperators
+import TensorKitTensors.HubbardOperators as HO
 using StableRNGs
 
 particle_syms = (Trivial, U1Irrep)
 spin_syms = (Trivial, U1Irrep, SU2Irrep)
+bases = (false, true)
+
+# operator availability, as determined by the symmetries each operator breaks:
+# - u_num, d_num, S_z and the u/d hopping and spin-flip pairs break SU2 spin symmetry
+# - S_x, S_y, S_plus, S_min only exist for trivial spin symmetry
+# - the pair (electron-number non-conserving) operators break U1 particle symmetry, and the
+#   triplet ones additionally break U1 spin symmetry
+# - e_num, h_num, e_plus_e_min, e_hopping, S_exchange and the singlet-pair correlators are
+#   compatible with every symmetry combination of the t-J model
+has_u_num(P, S) = S !== SU2Irrep
+has_S_z(P, S) = S !== SU2Irrep
+has_spin_ops(P, S) = S === Trivial
+has_pair(P, S) = P === Trivial && S !== SU2Irrep
+has_singlet(P, S) = P === Trivial
+has_triplet(P, S) = P === Trivial && S === Trivial
+
+# operators available for all supported symmetry combinations
+const ALWAYS = (e_num, h_num, e_plus_e_min, e_min_e_plus, e_hopping, S_exchange, Δ⁺ij_Δjk, Δ⁺ij_Δkl)
+
+@testset "basis transformations" begin
+    for (P, S, slave_fermion) in Iterators.product(particle_syms, spin_syms, bases)
+        U = basis_transform(P, S; slave_fermion)
+        @test U isa AbstractTensorMap{Int}
+        @test U' * U == one(U)
+        @test U * U' == one(U)
+        @test space(U) == (
+            desymmetrize(tj_space(P, S; slave_fermion)) ←
+                desymmetrize(tj_space(Trivial, Trivial; slave_fermion))
+        )
+    end
+    # the reference basis of each of the two bases is its own dense order
+    for slave_fermion in bases
+        U = basis_transform(Trivial, Trivial; slave_fermion)
+        @test U == one(U)
+    end
+
+    # the t-J model has no η-pairing doublet, and hence no SU2 particle symmetry
+    @test_throws ArgumentError tj_space(SU2Irrep, Trivial)
+    @test_throws ArgumentError tj_space(Trivial, Z2Irrep)
+    @test_throws ArgumentError e_num(ComplexF64, SU2Irrep, SU2Irrep)
+    @test_throws ArgumentError S_exchange(ComplexF64, SU2Irrep, Trivial; slave_fermion = true)
+
+    # real and wide scalar types are preserved, in both bases
+    for slave_fermion in bases
+        @test scalartype(u_num(Float64, U1Irrep, U1Irrep; slave_fermion)) === Float64
+        @test scalartype(S_exchange(Float64, U1Irrep, SU2Irrep; slave_fermion)) === Float64
+        @test scalartype(e_hopping(Complex{BigFloat}, U1Irrep, SU2Irrep; slave_fermion)) ===
+            Complex{BigFloat}
+        N_big = u_num(BigFloat, U1Irrep, U1Irrep; slave_fermion)
+        @test all(((c, b),) -> all(isinteger, b), blocks(N_big))
+    end
+end
 
 @testset "type inference" begin
     @test (@testinferred S_exchange()) isa AbstractTensorMap
+    @test (@testinferred S_exchange(Float64)) isa AbstractTensorMap
     @test (@testinferred S_exchange(U1Irrep, SU2Irrep)) isa AbstractTensorMap
     @test (@testinferred S_exchange(Float64, U1Irrep, SU2Irrep)) isa AbstractTensorMap
     @test (@testinferred S_exchange(U1Irrep, SU2Irrep; slave_fermion = true)) isa AbstractTensorMap
@@ -20,53 +75,126 @@ spin_syms = (Trivial, U1Irrep, SU2Irrep)
 end
 
 @testset "Compare symmetric with trivial tensors" begin
-    L = 4
-    for (particle_symmetry, spin_symmetry, slave_fermion) in Iterators.product(particle_syms, spin_syms, (false, true))
-        space = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
+    for (particle_symmetry, spin_symmetry, slave_fermion) in
+            Iterators.product(particle_syms, spin_syms, bases)
+        space = @testinferred tj_space(particle_symmetry, spin_symmetry; slave_fermion)
+        @test dim(space) == 3
 
-        O = e_plus_e_min(
-            ComplexF64, particle_symmetry, spin_symmetry;
-            slave_fermion
-        )
-        O_triv = e_plus_e_min(ComplexF64, Trivial, Trivial; slave_fermion)
-        test_operator(O, O_triv; L)
+        # element-wise comparison in the dense basis catches transposes and gauge errors
+        # that the spectral `test_operator` is blind to
+        U = basis_transform(particle_symmetry, spin_symmetry; slave_fermion)
 
-        O = e_num(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
-        O_triv = e_num(ComplexF64, Trivial, Trivial; slave_fermion)
-        test_operator(O, O_triv; L)
+        for (available, fs) in (
+                (true, ALWAYS),
+                (has_u_num(particle_symmetry, spin_symmetry), (u_num, d_num)),
+                (has_S_z(particle_symmetry, spin_symmetry), (S_z, S_plus_S_min, S_min_S_plus)),
+                (has_spin_ops(particle_symmetry, spin_symmetry), (S_x, S_plus, S_min)),
+                (has_pair(particle_symmetry, spin_symmetry), (u_min_d_min, d_min_u_min, u_plus_d_plus, d_plus_u_plus)),
+                (has_singlet(particle_symmetry, spin_symmetry), (singlet_plus, singlet_min)),
+                (has_triplet(particle_symmetry, spin_symmetry), (u_min_u_min, d_min_d_min, u_plus_u_plus, d_plus_d_plus)),
+            )
+            for f in fs
+                if available
+                    O = f(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
+                    O_triv = f(ComplexF64, Trivial, Trivial; slave_fermion)
+                    test_operator_dense(O, O_triv, U)
+                else
+                    @test_throws ArgumentError f(
+                        ComplexF64, particle_symmetry, spin_symmetry; slave_fermion
+                    )
+                end
+            end
+        end
+    end
+end
 
-        O = S_exchange(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
-        O_triv = S_exchange(ComplexF64, Trivial, Trivial; slave_fermion)
-        test_operator(O, O_triv; L)
+@testset "slave-fermion basis" begin
+    # the reference operators are transformed to the slave-fermion basis before they are
+    # symmetrized, which has to agree with transforming the symmetric operator itself
+    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+        for f in (
+                ALWAYS..., u_num, d_num, S_z, S_plus_S_min, S_min_S_plus, S_x, S_y, S_plus,
+                S_min, u_min_d_min, d_min_u_min, u_plus_d_plus, d_plus_u_plus, singlet_plus,
+                singlet_min, u_min_u_min, d_min_d_min, u_plus_u_plus, d_plus_d_plus,
+                u_plus_u_min, d_plus_d_min, u_min_u_plus, d_min_d_plus,
+            )
+            O = try
+                f(ComplexF64, particle_symmetry, spin_symmetry)
+            catch e
+                e isa ArgumentError || rethrow()
+                continue
+            end
+            O_sf = f(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion = true)
+            @test O_sf ≈ transform_slave_fermion(O)
+        end
+    end
+end
 
-        O = Δ⁺ij_Δjk(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
-        O_triv = Δ⁺ij_Δjk(ComplexF64, Trivial, Trivial; slave_fermion)
-        test_operator(O, O_triv; L = 5)
+@testset "Hubbard projection" begin
+    # the relation to the Hubbard operators: project out the doubly occupied state
+    for (particle_symmetry, spin_symmetry) in Iterators.product(particle_syms, spin_syms)
+        proj = tj_projector(particle_symmetry, spin_symmetry)
+        @test proj isa AbstractTensorMap{Int}
+        @test proj * proj' ≈ id(tj_space(particle_symmetry, spin_symmetry))
+        for name in (
+                :e_num, :h_num, :u_num, :d_num, :S_z, :S_x, :S_plus, :S_min,
+                :u_plus_u_min, :d_plus_d_min, :e_plus_e_min, :e_min_e_plus, :e_hopping,
+                :u_min_d_min, :d_min_u_min, :u_min_u_min, :d_min_d_min,
+                :singlet_plus, :singlet_min, :S_plus_S_min, :S_min_S_plus, :S_exchange,
+                :singlet_plus_singlet_min_3site, :singlet_plus_singlet_min_4site,
+            )
+            O_tj = try
+                getproperty(TJOperators, name)(ComplexF64, particle_symmetry, spin_symmetry)
+            catch e
+                e isa ArgumentError || rethrow()
+                continue
+            end
+            O_hub = getproperty(HO, name)(ComplexF64, particle_symmetry, spin_symmetry)
+            projⁿ = reduce(⊗, ntuple(Returns(proj), numout(O_hub)))
+            @test projⁿ * O_hub * projⁿ' ≈ O_tj
+        end
+    end
+end
 
-        O = Δ⁺ij_Δkl(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
-        O_triv = Δ⁺ij_Δkl(ComplexF64, Trivial, Trivial; slave_fermion)
-        test_operator(O, O_triv; L = 5)
+@testset "regression values" begin
+    # regression check: hand-written symmetric operators are easily transposed. The dense
+    # indices of the basis states are read off from the basis transform, whose columns are
+    # ordered as (|0⟩, |↑⟩, |↓⟩) in the plain t-J basis.
+    for (P, S) in Iterators.product(particle_syms, spin_syms)
+        U = convert(Array, basis_transform(P, S))
+        i0 = findfirst(==(1), U[:, 1])
+        iu = findfirst(==(1), U[:, 2])
 
-        if particle_symmetry == Trivial
-            O = singlet_plus(ComplexF64, particle_symmetry, spin_symmetry; slave_fermion)
-            O_triv = singlet_plus(ComplexF64, Trivial, Trivial; slave_fermion)
-            test_operator(O, O_triv; L)
+        A = convert(Array, e_plus_e_min(ComplexF64, P, S))
+        @test A[iu, i0, i0, iu] ≈ 1        # |↑,0⟩ ↤ |0,↑⟩
+        @test abs(A[i0, iu, iu, i0]) < 1.0e-12
+
+        if has_S_z(P, S)
+            id_ = findfirst(==(1), U[:, 3])
+            B = convert(Array, S_plus_S_min(ComplexF64, P, S))
+            @test B[iu, id_, id_, iu] ≈ 1  # |↑,↓⟩ ↤ |↓,↑⟩
+            @test abs(B[id_, iu, iu, id_]) < 1.0e-12
         end
     end
 end
 
 @testset "basic properties" begin
-    for (particle_symmetry, spin_symmetry, slave_fermion) in Iterators.product(particle_syms, spin_syms, (false, true))
-        # test hopping operator
+    for (particle_symmetry, spin_symmetry, slave_fermion) in
+            Iterators.product(particle_syms, spin_syms, bases)
+        pspace = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
+
+        # hopping operators
         epem = e_plus_e_min(particle_symmetry, spin_symmetry; slave_fermion)
         emep = e_min_e_plus(particle_symmetry, spin_symmetry; slave_fermion)
         @test epem' ≈ -emep ≈ swap_2sites(epem)
-        if spin_symmetry !== SU2Irrep
-            dpdm = d_plus_d_min(particle_symmetry, spin_symmetry)
-            dmdp = d_min_d_plus(particle_symmetry, spin_symmetry)
+        @test e_hopping(particle_symmetry, spin_symmetry; slave_fermion)' ≈
+            e_hopping(particle_symmetry, spin_symmetry; slave_fermion)
+        if has_u_num(particle_symmetry, spin_symmetry)
+            dpdm = d_plus_d_min(particle_symmetry, spin_symmetry; slave_fermion)
+            dmdp = d_min_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
             @test dpdm' ≈ -dmdp ≈ swap_2sites(dpdm)
-            upum = u_plus_u_min(particle_symmetry, spin_symmetry)
-            umup = u_min_u_plus(particle_symmetry, spin_symmetry)
+            upum = u_plus_u_min(particle_symmetry, spin_symmetry; slave_fermion)
+            umup = u_min_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
             @test upum' ≈ -umup ≈ swap_2sites(upum)
         else
             @test_throws ArgumentError d_plus_d_min(particle_symmetry, spin_symmetry; slave_fermion)
@@ -75,34 +203,30 @@ end
             @test_throws ArgumentError u_min_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
         end
 
-        # test number operator
-        if spin_symmetry !== SU2Irrep
-            pspace = tj_space(particle_symmetry, spin_symmetry; slave_fermion)
-            @test e_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                u_num(particle_symmetry, spin_symmetry; slave_fermion) +
-                d_num(particle_symmetry, spin_symmetry; slave_fermion)
-            @test u_num(particle_symmetry, spin_symmetry; slave_fermion) *
-                d_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                d_num(particle_symmetry, spin_symmetry; slave_fermion) *
-                u_num(particle_symmetry, spin_symmetry; slave_fermion) ≈
-                zeros(pspace ← pspace)
-            @test TensorKit.id(pspace) ≈
-                h_num(particle_symmetry, spin_symmetry; slave_fermion) +
-                e_num(particle_symmetry, spin_symmetry; slave_fermion)
+        # number operators
+        @test TensorKit.id(pspace) ≈
+            h_num(particle_symmetry, spin_symmetry; slave_fermion) +
+            e_num(particle_symmetry, spin_symmetry; slave_fermion)
+        if has_u_num(particle_symmetry, spin_symmetry)
+            nu = u_num(particle_symmetry, spin_symmetry; slave_fermion)
+            nd = d_num(particle_symmetry, spin_symmetry; slave_fermion)
+            @test e_num(particle_symmetry, spin_symmetry; slave_fermion) ≈ nu + nd
+            # no double occupancy
+            @test nu * nd ≈ nd * nu ≈ zeros(pspace ← pspace)
         else
             @test_throws ArgumentError u_num(particle_symmetry, spin_symmetry; slave_fermion)
             @test_throws ArgumentError d_num(particle_symmetry, spin_symmetry; slave_fermion)
         end
 
-        # test singlet operators
-        if particle_symmetry == Trivial
+        # singlet operators
+        if has_singlet(particle_symmetry, spin_symmetry)
             singm = singlet_min(particle_symmetry, spin_symmetry; slave_fermion)
             @test swap_2sites(singm) ≈ singm
-            if spin_symmetry !== SU2Irrep
+            @test singm ≈ singlet_plus(particle_symmetry, spin_symmetry; slave_fermion)'
+            if has_pair(particle_symmetry, spin_symmetry)
                 umdm = u_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
                 dmum = d_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
                 @test swap_2sites(umdm) ≈ -dmum
-
                 @test singm ≈ (-umdm + dmum) / sqrt(2)
                 updp = u_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
                 dpup = d_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
@@ -111,19 +235,21 @@ end
         else
             @test_throws ArgumentError singlet_plus(particle_symmetry, spin_symmetry; slave_fermion)
             @test_throws ArgumentError singlet_min(particle_symmetry, spin_symmetry; slave_fermion)
+        end
+        if !has_pair(particle_symmetry, spin_symmetry)
             @test_throws ArgumentError u_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
             @test_throws ArgumentError d_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
             @test_throws ArgumentError u_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
             @test_throws ArgumentError d_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
         end
 
-        # test 3-site singlet hopping operator
+        # 3-site singlet hopping operator
         O_ijk = Δ⁺ij_Δjk(particle_symmetry, spin_symmetry; slave_fermion)
         O_kji = permute(O_ijk, ((3, 2, 1), (6, 5, 4)))
         @test O_kji ≈ O_ijk'
 
-        # test triplet operators
-        if particle_symmetry == Trivial && spin_symmetry == Trivial
+        # triplet operators
+        if has_triplet(particle_symmetry, spin_symmetry)
             umum = u_min_u_min(particle_symmetry, spin_symmetry; slave_fermion)
             dmdm = d_min_d_min(particle_symmetry, spin_symmetry; slave_fermion)
             upup = u_plus_u_plus(particle_symmetry, spin_symmetry; slave_fermion)
@@ -139,14 +265,13 @@ end
             @test_throws ArgumentError d_plus_d_plus(particle_symmetry, spin_symmetry; slave_fermion)
         end
 
-        # test spin operator
-        if spin_symmetry == Trivial
+        # spin operators
+        if has_spin_ops(particle_symmetry, spin_symmetry)
             test_spin_algebra(
                 S_x(particle_symmetry, spin_symmetry; slave_fermion),
                 S_y(particle_symmetry, spin_symmetry; slave_fermion),
                 S_z(particle_symmetry, spin_symmetry; slave_fermion),
             )
-            # test S_plus and S_min
             @test S_plus_S_min(particle_symmetry, spin_symmetry; slave_fermion) ≈
                 S_plus(particle_symmetry, spin_symmetry; slave_fermion) ⊗
                 S_min(particle_symmetry, spin_symmetry; slave_fermion)
@@ -158,9 +283,11 @@ end
             @test_throws ArgumentError S_min(particle_symmetry, spin_symmetry; slave_fermion)
             @test_throws ArgumentError S_x(particle_symmetry, spin_symmetry; slave_fermion)
             @test_throws ArgumentError S_y(particle_symmetry, spin_symmetry; slave_fermion)
-            if spin_symmetry != U1Irrep
-                @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry; slave_fermion)
-            end
+        end
+        if !has_S_z(particle_symmetry, spin_symmetry)
+            @test_throws ArgumentError S_z(particle_symmetry, spin_symmetry; slave_fermion)
+            @test_throws ArgumentError S_plus_S_min(particle_symmetry, spin_symmetry; slave_fermion)
+            @test_throws ArgumentError S_min_S_plus(particle_symmetry, spin_symmetry; slave_fermion)
         end
     end
 end
@@ -177,7 +304,7 @@ end
 @testset "spectrum" begin
     rng = StableRNG(123)
     L = 4
-    for slave_fermion in (false, true)
+    for slave_fermion in bases
         t, J, mu = rand(rng, 3)
         H_triv = tjhamiltonian(Trivial, Trivial; t, J, mu, L, slave_fermion)
         vals_triv = expanded_eigenvalues(H_triv)
@@ -197,7 +324,7 @@ end
     rng = StableRNG(123)
     t, J = rand(rng, 2)
     true_eigenvals = sort(vcat(-J, fill(-t, 2), fill(t, 2), fill(0.0, 4)))
-    for (P, S, slave_fermion) in Iterators.product(particle_syms, spin_syms, (false, true))
+    for (P, S, slave_fermion) in Iterators.product(particle_syms, spin_syms, bases)
         H = tjhamiltonian(P, S; t, J, mu = 0.0, L = 2, slave_fermion)
         eigenvals = expanded_eigenvalues(H)
         @test eigenvals ≈ true_eigenvals


### PR DESCRIPTION
Brings `TJOperators` in line with every other operator module: dense reference operators defined first, symmetric ones obtained by basis transformation + projection through `@operator`. Previously all 31 operators were generated by an `@eval` loop projecting the `HubbardOperators` counterparts, with docstrings scraped from Hubbard and patched by string substitution.

### The two bases

`slave_fermion` is a parameter of the reference *space*, like `spin` in `SpinOperators`: `@operator` forwards keywords to the reference method as well as to the hook, and `(Trivial, Trivial)` never reaches `_symmetrize_operator`, so the reference has to return the operator in the requested basis. Flipping the parity also reorders the reference dense basis (`|0⟩, |↑⟩, |↓⟩` → `|↑⟩, |↓⟩, |0⟩`), so `basis_transform` takes `slave_fermion` too. It comes out a pure integer permutation in both bases; the staggered sign of the slave-fermion representation stays inside `transform_slave_fermion`, applied once to the assembled N-site reference.

### Other changes

- `tj_space` is dispatched on the symmetries and rejects `SU2Irrep` particle symmetry with a dedicated error (no η-pairing doublet without `|↑↓⟩`).
- Real docstrings per operator, without the unreachable `|↑↓⟩` matrix elements the transplanted ones advertised.
- Fixes three misaligned aliases of the old positional `zip`: `u⁺u⁺`/`d⁻d⁻` were swapped with `d_min_d_min`/`u_plus_u_plus`, and `S⁺S⁻`/`S⁻S⁺` with each other.
- `tj_projector` stays public and documents the projection relation to `HubbardOperators`, which the tests now check.
- Tests mirror `test/hubbardoperators.jl`: availability predicates, basis-transform unitarity and scalar-type preservation, `test_operator_dense` instead of the spectral comparison, transpose-regression values, the Hubbard projection relation, and the invariant `O(…; slave_fermion = true) ≈ transform_slave_fermion(O(…))`.
- Drops the `spectrum` testsets (t-J and Hubbard), subsumed by the element-wise comparison; the analytic ED testsets are kept.

Verified against the pre-refactor implementation: all 31 operators match element-wise for the 6 symmetry combinations × both bases. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)